### PR TITLE
Fix UI crash when showing queries pre-Lollipop

### DIFF
--- a/Android/app/src/main/java/app/intra/RecyclerAdapter.java
+++ b/Android/app/src/main/java/app/intra/RecyclerAdapter.java
@@ -15,6 +15,9 @@ limitations under the License.
 */
 package app.intra;
 
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.v4.content.ContextCompat;
 import app.intra.util.CountryMap;
 import app.intra.util.DnsPacket;
 import app.intra.util.DnsTransaction;
@@ -352,6 +355,20 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
       assert viewType == TYPE_TRANSACTION;
       View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.transaction_row,
           parent, false);
+
+      // Workaround for lack of vector drawable background support in pre-Lollipop Android.
+      View expand = v.findViewById(R.id.expand);
+      // getDrawable automatically rasterizes vector drawables as needed on pre-Lollipop Android.
+      // See https://stackoverflow.com/questions/29041027/android-getresources-getdrawable-deprecated-api-22
+      Drawable expander = ContextCompat.getDrawable(activity, R.drawable.expander);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        // Only available in API 16+.
+        expand.setBackground(expander);
+      } else {
+        // Deprecated starting in API 16.
+        expand.setBackgroundDrawable(expander);
+      }
+
       return new TransactionViewHolder(v);
     }
   }

--- a/Android/app/src/main/res/layout/transaction_row.xml
+++ b/Android/app/src/main/res/layout/transaction_row.xml
@@ -18,11 +18,14 @@
 
     <TextView
         android:id="@+id/flag"
-        android:layout_width="40dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start|center_vertical"
-        android:layout_margin="8dp"
         android:layout_weight="0"
+        android:layout_margin="8dp"
+        android:layout_gravity="start|center_vertical"
+        android:ellipsize="none"
+        android:minWidth="40dp"
+        android:singleLine="true"
         android:textAlignment="center"
         android:textAppearance="@style/TextAppearance.AppCompat.Headline"
         tools:text="🇩🇪"/>
@@ -52,6 +55,9 @@
         android:textColor="@color/accent_good"
         tools:text="17:54:11"/>
 
+    <!-- This button's background image is set by Java code as a workaround for lack of support
+    for vector background drawables on pre-Lollipop Android.  See
+    https://medium.com/@ferrand.d/can-you-and-should-you-use-vector-drawables-a-cheatsheet-32a2e1cc2ecf-->
     <ToggleButton
         android:id="@+id/expand"
         android:layout_width="24dp"
@@ -59,7 +65,6 @@
         android:layout_gravity="end|center_vertical"
         android:layout_margin="10dp"
         android:layout_weight="0"
-        android:background="@drawable/expander"
         android:textOff=""
         android:textOn=""/>
   </LinearLayout>


### PR DESCRIPTION
This crash was occurring because older versions of Android
don't support using a vector drawable as a background image,
and the AppCompat libraries don't help in this case.

Additionally, this change improves query history layout on
devices that don't have flag emoji.