### PR TITLE
Centralize preference state

### DIFF
--- a/Android/app/src/main/java/app/intra/DnsVpnService.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnService.java
@@ -87,7 +87,7 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
 
   @Override
   public synchronized int onStartCommand(Intent intent, int flags, int startId) {
-    url = intent.getStringExtra(Names.URL.name());
+    url = Preferences.getServerUrl(this);
     Log.i(LOG_TAG, String.format("Starting DNS VPN service, url=%s", url));
 
     if (networkManager != null) {

--- a/Android/app/src/main/java/app/intra/GoogleServerDatabase.java
+++ b/Android/app/src/main/java/app/intra/GoogleServerDatabase.java
@@ -16,7 +16,6 @@ limitations under the License.
 package app.intra;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 
 import android.util.Log;
@@ -47,8 +46,6 @@ import okhttp3.Dns;
 public class GoogleServerDatabase implements Dns {
 
   private static final String LOG_TAG = "GoogleServerDatabase";
-  private static final String EXTRA_SERVERS_V4_KEY = "extraServersV4";
-  private static final String EXTRA_SERVERS_V6_KEY = "extraServersV6";
 
   // Max number of these IP addresses, selected at random, to attempt before declaring failure.
   private static final int MAX_ATTEMPTS = 10;
@@ -124,11 +121,8 @@ public class GoogleServerDatabase implements Dns {
       FirebaseCrash.logcat(Log.INFO, LOG_TAG, "VPN was destroyed before bootstrap started");
       return new DualStackResult(new String[0], new String[0]);
     }
-    SharedPreferences settings = context.getSharedPreferences(MainActivity.class.getSimpleName(),
-        Context.MODE_PRIVATE);
-
-    Set<String> v4set = settings.getStringSet(EXTRA_SERVERS_V4_KEY, new HashSet<String>());
-    Set<String> v6set = settings.getStringSet(EXTRA_SERVERS_V6_KEY, new HashSet<String>());
+    Set<String> v4set = Preferences.getExtraGoogleV4Servers(context);
+    Set<String> v6set = Preferences.getExtraGoogleV6Servers(context);
     String[] dummy = new String[0];
     return new DualStackResult(v4set.toArray(dummy), v6set.toArray(dummy));
   }
@@ -148,15 +142,7 @@ public class GoogleServerDatabase implements Dns {
       FirebaseCrash.logcat(Log.INFO, LOG_TAG, "VPN was destroyed before bootstrap completed");
       return;
     }
-    SharedPreferences settings =
-        context.getSharedPreferences(MainActivity.class.getSimpleName(),
-            Context.MODE_PRIVATE);
-    SharedPreferences.Editor editor = settings.edit();
-
-    editor.putStringSet(EXTRA_SERVERS_V4_KEY,
-        new HashSet<String>(Arrays.asList(servers.getV4())));
-    editor.putStringSet(EXTRA_SERVERS_V6_KEY,
-        new HashSet<String>(Arrays.asList(servers.getV6())));
-    editor.apply();
+    Preferences.setExtraGoogleV4Servers(context, servers.getV4());
+    Preferences.setExtraGoogleV6Servers(context, servers.getV6());
   }
 }

--- a/Android/app/src/main/java/app/intra/Preferences.java
+++ b/Android/app/src/main/java/app/intra/Preferences.java
@@ -1,0 +1,106 @@
+package app.intra;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Static class representing on-disk storage of mutable state.  Collecting this all in one class
+ * helps to reduce duplication of code using SharedPreferences, allows settings to be read and
+ * written by separate components, and also helps to improve preference naming consistency.
+ */
+public class Preferences {
+  private static final String APPROVED_KEY = "approved";
+  private static final String EXTRA_SERVERS_V4_KEY = "extraServersV4";
+  private static final String EXTRA_SERVERS_V6_KEY = "extraServersV6";
+  private static final String SERVER_KEY = "server";
+
+  private static final String MAIN_PREFS_NAME = "MainActivity";
+
+  // The approval state is currently stored in a separate preferences file.
+  // TODO: Unify preferences into a single file.
+  private static final String APPROVAL_PREFS_NAME = "IntroState";
+
+  private static SharedPreferences getSettings(Context context) {
+    return context.getSharedPreferences(MAIN_PREFS_NAME, Context.MODE_PRIVATE);
+  }
+
+  public static String getServerName(Context context) {
+    SharedPreferences settings = getSettings(context);
+
+    String defaultDomain = context.getResources().getStringArray(R.array.domains)[0];
+    return settings.getString(SERVER_KEY, defaultDomain);
+  }
+
+  public static boolean setServerName(Context context, String name) {
+    String oldName = getServerName(context);
+    if (name.equals(oldName)) {
+      return true;
+    }
+    final List<String> knownNames =
+        Arrays.asList(context.getResources().getStringArray(R.array.domains));
+    if (!knownNames.contains(name)) {
+      return false;
+    }
+    SharedPreferences settings = getSettings(context);
+    SharedPreferences.Editor editor = settings.edit();
+
+    editor.putString(SERVER_KEY, name);
+    editor.apply();
+
+    return true;
+  }
+
+  public static String getServerUrl(Context context) {
+    String[] domains = context.getResources().getStringArray(R.array.domains);
+    String[] urls = context.getResources().getStringArray(R.array.urls);
+    String domain = getServerName(context);
+    for (int i = 0; i < domains.length; ++i) {
+      if (domains[i].equals(domain)) {
+        return urls[i];
+      }
+    }
+    return null;
+  }
+
+  public static Set<String> getExtraGoogleV4Servers(Context context) {
+    return getSettings(context).getStringSet(EXTRA_SERVERS_V4_KEY, new HashSet<String>());
+  }
+
+  public static void setExtraGoogleV4Servers(Context context, String[] servers) {
+    SharedPreferences.Editor editor = getSettings(context).edit();
+
+    editor.putStringSet(EXTRA_SERVERS_V4_KEY,
+        new HashSet<String>(Arrays.asList(servers)));
+    editor.apply();
+  }
+
+  public static Set<String> getExtraGoogleV6Servers(Context context) {
+    return getSettings(context).getStringSet(EXTRA_SERVERS_V6_KEY, new HashSet<String>());
+  }
+
+  public static void setExtraGoogleV6Servers(Context context, String[] servers) {
+    SharedPreferences.Editor editor = getSettings(context).edit();
+
+    editor.putStringSet(EXTRA_SERVERS_V6_KEY,
+        new HashSet<String>(Arrays.asList(servers)));
+    editor.apply();
+  }
+
+  private static SharedPreferences getApprovalSettings(Context context) {
+    return context.getSharedPreferences(APPROVAL_PREFS_NAME, Context.MODE_PRIVATE);
+  }
+
+  public static boolean getWelcomeApproved(Context context) {
+    return getApprovalSettings(context).getBoolean(APPROVED_KEY, false);
+  }
+
+  public static void setWelcomeApproved(Context context, boolean approved) {
+    SharedPreferences.Editor editor = getApprovalSettings(context).edit();
+    editor.putBoolean(APPROVED_KEY, approved);
+    editor.apply();
+  }
+}

--- a/Android/app/src/main/java/app/intra/WelcomePopup.java
+++ b/Android/app/src/main/java/app/intra/WelcomePopup.java
@@ -17,7 +17,6 @@ package app.intra;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.text.method.LinkMovementMethod;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -28,13 +27,8 @@ import android.widget.PopupWindow;
 import android.widget.TextView;
 
 public class WelcomePopup {
-
-  private static final String PREFS_NAME = "IntroState";
-  private static final String APPROVED_KEY = "approved";
-
   public static boolean shouldShow(Activity activity) {
-    SharedPreferences settings = activity.getSharedPreferences(PREFS_NAME, 0);
-    return !settings.getBoolean(APPROVED_KEY, false);
+    return !Preferences.getWelcomeApproved(activity);
   }
 
   public WelcomePopup(final MainActivity mainActivity) {
@@ -50,11 +44,7 @@ public class WelcomePopup {
     acceptButton.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
-        SharedPreferences settings = mainActivity.getSharedPreferences(PREFS_NAME,
-            0);
-        SharedPreferences.Editor editor = settings.edit();
-        editor.putBoolean(APPROVED_KEY, true);
-        editor.apply();
+        Preferences.setWelcomeApproved(mainActivity, true);
         popupWindow.dismiss();
       }
     });

--- a/Android/app/src/main/java/app/intra/util/Names.java
+++ b/Android/app/src/main/java/app/intra/util/Names.java
@@ -20,7 +20,6 @@ package app.intra.util;
 public enum Names {
   BOOTSTRAP,
   BOOTSTRAP_FAILED,
-  DATA,
   DNS_STATUS,
   DROPPED,
   LATENCY,
@@ -28,5 +27,4 @@ public enum Names {
   RESOLVED,
   RESULT,
   TRANSACTION,
-  URL,
 }


### PR DESCRIPTION
In addition to improving code health, this removes the VPN
service's reliance on Intent extras, which is a prerequisite
for always-on/autostart.