### PR TITLE
Add autostart-on-boot

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="true"
@@ -28,6 +29,16 @@
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
         </service>
+
+        <receiver android:name="app.intra.AutoStarter" android:enabled="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
         <!-- Uncomment the below line for network performance debug logging -->
         <!-- <meta-data android:name="firebase_performance_logcat_enabled" android:value="true" /> -->
     </application>

--- a/Android/app/src/main/java/app/intra/AutoStarter.java
+++ b/Android/app/src/main/java/app/intra/AutoStarter.java
@@ -1,0 +1,38 @@
+package app.intra;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.VpnService;
+import android.util.Log;
+import com.google.firebase.crash.FirebaseCrash;
+
+/**
+ * Broadcast receiver that runs on boot.
+ */
+
+public class AutoStarter extends BroadcastReceiver {
+
+  private static String LOG_TAG = "AutoStarter";
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    FirebaseCrash.logcat(Log.DEBUG, LOG_TAG, "Boot event");
+    if (DnsVpnServiceState.getInstance().isDnsVpnServiceStarting()) {
+      // The service is already started or starting, so there's no work to do.
+      FirebaseCrash.logcat(Log.DEBUG, LOG_TAG, "Already running");
+      return;
+    }
+    if (Preferences.getVpnEnabled(context)) {
+      FirebaseCrash.logcat(Log.DEBUG, LOG_TAG, "Autostart enabled");
+      if (VpnService.prepare(context) != null) {
+        // prepare() returns a non-null intent if VPN permission has not been granted.
+        FirebaseCrash.logcat(Log.WARN, LOG_TAG, "VPN permission not granted");
+        return;
+      }
+      Intent startServiceIntent = new Intent(context, DnsVpnService.class);
+      context.startService(startServiceIntent);
+      DnsVpnServiceState.getInstance().setDnsVpnServiceStarting();
+    }
+  }
+}

--- a/Android/app/src/main/java/app/intra/AutoStarter.java
+++ b/Android/app/src/main/java/app/intra/AutoStarter.java
@@ -8,9 +8,8 @@ import android.util.Log;
 import com.google.firebase.crash.FirebaseCrash;
 
 /**
- * Broadcast receiver that runs on boot.
+ * Broadcast receiver that runs on boot, and also when the app is restarted due to an update.
  */
-
 public class AutoStarter extends BroadcastReceiver {
 
   private static String LOG_TAG = "AutoStarter";

--- a/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
+++ b/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
@@ -79,6 +79,7 @@ public class DnsResolverUdpToHttps extends Thread {
   // In addition to reading DNS requests from the VPN interface and forwarding them via HTTPS, this
   // thread is responsible for maintaining a connected socket to Google's DNS-over-HTTPS API.
   public void run() {
+    FirebaseCrash.logcat(Log.DEBUG, LOG_TAG, "Query thread starting");
     if (tunFd == null) {
       // This check is necessary due to a race, where the VPN has been closed and the device regains
       // network connectivity before the service stops. As a result the TUN file descriptor is null

--- a/Android/app/src/main/java/app/intra/DnsVpnService.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnService.java
@@ -209,6 +209,7 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
 
     tunFd = establishVpn();
     if (tunFd == null) {
+      FirebaseCrash.logcat(Log.WARN, LOG_TAG, "Failed to get TUN device");
       stopSelf();
       return;
     }
@@ -289,6 +290,7 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
 
   private synchronized void startDnsResolver() {
     if (dnsResolver == null && serverConnection != null) {
+      FirebaseCrash.logcat(Log.INFO, LOG_TAG, "Starting DNS resolver");
       dnsResolver = new DnsResolverUdpToHttps(tunFd, serverConnection);
       dnsResolver.start();
     }
@@ -333,6 +335,9 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
     FirebaseCrash.report(new Error("onRevoke"));
     stopDnsResolver();
     stopSelf();
+
+    // Disable autostart if VPN permission is revoked.
+    Preferences.setVpnEnabled(this, false);
 
     // Show revocation warning
     Notification.Builder builder;

--- a/Android/app/src/main/java/app/intra/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/MainActivity.java
@@ -363,6 +363,7 @@ public class MainActivity extends AppCompatActivity implements PopupMenu.OnMenuI
   }
 
   private void startDnsVpnService() {
+    Preferences.setVpnEnabled(this, true);
     Intent startServiceIntent = new Intent(this, DnsVpnService.class);
     startService(startServiceIntent);
     DnsVpnServiceState.getInstance().setDnsVpnServiceStarting();
@@ -378,6 +379,7 @@ public class MainActivity extends AppCompatActivity implements PopupMenu.OnMenuI
     if (dnsVpnService != null) {
       dnsVpnService.signalStopService(true /* user initiated */);
     }
+    Preferences.setVpnEnabled(this, false);
   }
 
   private Queue<DnsTransaction> getHistory() {

--- a/Android/app/src/main/java/app/intra/Preferences.java
+++ b/Android/app/src/main/java/app/intra/Preferences.java
@@ -15,6 +15,7 @@ import java.util.Set;
 public class Preferences {
 
   private static final String APPROVED_KEY = "approved";
+  private static final String ENABLED_KEY = "enabled";
   private static final String EXTRA_SERVERS_V4_KEY = "extraServersV4";
   private static final String EXTRA_SERVERS_V6_KEY = "extraServersV6";
   private static final String SERVER_KEY = "server";
@@ -29,9 +30,18 @@ public class Preferences {
     return context.getSharedPreferences(MAIN_PREFS_NAME, Context.MODE_PRIVATE);
   }
 
+  public static boolean getVpnEnabled(Context context) {
+    return getSettings(context).getBoolean(ENABLED_KEY, false);
+  }
+
+  public static void setVpnEnabled(Context context, boolean enabled) {
+    SharedPreferences.Editor editor = getSettings(context).edit();
+    editor.putBoolean(ENABLED_KEY, enabled);
+    editor.apply();
+  }
+
   public static String getServerName(Context context) {
     SharedPreferences settings = getSettings(context);
-
     String defaultDomain = context.getResources().getStringArray(R.array.domains)[0];
     return settings.getString(SERVER_KEY, defaultDomain);
   }


### PR DESCRIPTION
This change relaunches Intra on boot if it was active at shutdown,
so that the VPN stays active until the user turns it off.

This is relevant to #11.