### PR TITLE
Allow apps to bypass the VPN

### DIFF
--- a/Android/app/src/main/java/app/intra/DnsVpnService.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnService.java
@@ -436,7 +436,11 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
               .addDnsServer(privateIpv6Address.router);
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        builder = builder.setBlocking(true); // Only available in API >= 21
+        // Only available in API >= 21
+        builder = builder.setBlocking(true);
+        // Some WebRTC apps rely on the ability to bind to specific interfaces, which is only
+        // possible if we allow bypass.
+        builder = builder.allowBypass();
 
         try {
           // Workaround for any app incompatibility bugs.


### PR DESCRIPTION
In practice, apps could easily bypass Intra anyway, e.g. by
sending queries to a hardcoded resolver.  Explicitly allowing
bypass fixes #18 (interference with some WebRTC-based apps).