### PR TITLE
Show a warning when a VPN is already running

### DIFF
--- a/Android/.idea/codeStyleSettings.xml
+++ b/Android/.idea/codeStyleSettings.xml
@@ -224,6 +224,6 @@
         </codeStyleSettings>
       </value>
     </option>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="GoogleStyle" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Google Configuration Checker Style" />
   </component>
 </project>

--- a/Android/app/src/main/java/app/intra/DnsVpnService.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnService.java
@@ -24,7 +24,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.PeriodicSync;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
@@ -375,10 +374,7 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
 
   @Override
   public void onRevoke() {
-    FirebaseCrash.logcat(Log.ERROR, LOG_TAG, "VPN service revoked.");
-    // Revocation isn't intrinsically an error, but it can occur as a result of error conditions,
-    // and user-initiated revocation is expected to be extremely rare.
-    FirebaseCrash.report(new Error("onRevoke"));
+    FirebaseCrash.logcat(Log.WARN, LOG_TAG, "VPN service revoked.");
     stopDnsResolver();
     stopSelf();
 

--- a/Android/app/src/main/res/layout/main_content.xml
+++ b/Android/app/src/main/res/layout/main_content.xml
@@ -56,6 +56,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/indicator"/>
 
+    <TextView
+        android:id="@+id/os_status"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dns_switch"
+        tools:text="@string/vpn_active"/>
+
     <app.intra.util.HistoryGraph
         android:id="@+id/graph"
         android:layout_width="match_parent"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -97,6 +97,11 @@
     disable
   </string>
 
+  <string name="vpn_active"
+          description="Warning text shown on the main screen before the user starts Intra">
+    Intra has detected another VPN on your device.  That VPN will be disabled if you enable Intra.
+  </string>
+
   <string name="system_details"
           description="This is the title of a section containing information on the system configuration and
   status.">


### PR DESCRIPTION
This change also disables reporting of "onRevoke" as a crash.
This "crash" has occurred thousands of times without any
corresponding user complaints, so it seems likely to be
occurring when the user activates a VPN that replaces Intra.
Hopefully, this text will help users understand this interaction
better.