### PR TITLE
Make landscape layouts work

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="app.intra.MainActivity"
-            android:screenOrientation="portrait">
+        <activity android:name="app.intra.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/Android/app/src/main/java/app/intra/PadNavigationView.java
+++ b/Android/app/src/main/java/app/intra/PadNavigationView.java
@@ -1,0 +1,37 @@
+package app.intra;
+
+import com.google.android.material.navigation.NavigationView;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.core.view.WindowInsetsCompat;
+
+/**
+ * This is a NavigationView that always respects the system insets, even if it has no menu of its
+ * own.
+ */
+
+public class PadNavigationView extends NavigationView {
+  public PadNavigationView(Context context) {
+    super(context);
+  }
+
+  public PadNavigationView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public PadNavigationView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+  }
+
+  @Override
+  protected void onInsetsChanged(WindowInsetsCompat insets) {
+    // Normally, NavigationView applies the system inset padding to the first menu item, not to the
+    // NavigationView itself.  This doesn't work if the view has no MenuItems.  By overriding the
+    // inset listener and applying the padding directly to the NavigationView, we can get correct
+    // padding behavior even when there are no menu items.
+    setPadding(getPaddingLeft(), insets.getSystemWindowInsetTop(), getPaddingRight(),
+        getPaddingBottom());
+  }
+}

--- a/Android/app/src/main/java/app/intra/SettingsFragment.java
+++ b/Android/app/src/main/java/app/intra/SettingsFragment.java
@@ -40,8 +40,11 @@ import androidx.preference.PreferenceFragmentCompat;
  */
 
 public class SettingsFragment extends PreferenceFragmentCompat {
-  private List<String> labels;
-  private List<String> packageNames;
+  private static final String LABELS_KEY = "labels";
+  private static final String PACKAGENAMES_KEY = "packageNames";
+
+  private ArrayList<String> labels = null;
+  private ArrayList<String> packageNames = null;
   private MultiSelectListPreference apps = null;
 
   /**
@@ -76,7 +79,19 @@ public class SettingsFragment extends PreferenceFragmentCompat {
   }
 
   @Override
+  public void onSaveInstanceState(Bundle savedInstanceState) {
+    savedInstanceState.putStringArrayList(LABELS_KEY, labels);
+    savedInstanceState.putStringArrayList(PACKAGENAMES_KEY, packageNames);
+  }
+
+  @Override
   public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+    if (savedInstanceState != null) {
+      // Restore the app list state.
+      labels = savedInstanceState.getStringArrayList(LABELS_KEY);
+      packageNames = savedInstanceState.getStringArrayList(PACKAGENAMES_KEY);
+    }
+
     // Load the preferences from an XML resource
     addPreferencesFromResource(R.xml.preferences);
     apps = (MultiSelectListPreference)findPreference(PersistentState.APPS_KEY);

--- a/Android/app/src/main/java/app/intra/util/HistoryGraph.java
+++ b/Android/app/src/main/java/app/intra/util/HistoryGraph.java
@@ -149,6 +149,34 @@ public class HistoryGraph extends View {
   }
 
   @Override
+  protected void onMeasure(int w, int h) {
+    int wMode = MeasureSpec.getMode(w);
+    int width;
+    if (wMode == MeasureSpec.AT_MOST || wMode == MeasureSpec.EXACTLY) {
+      // Always fill the whole width.
+      width = MeasureSpec.getSize(w);
+    } else {
+      width = getSuggestedMinimumWidth();
+    }
+
+    int hMode = MeasureSpec.getMode(h);
+    int height;
+    if (hMode == MeasureSpec.EXACTLY) {
+      // Nothing we can do about it.
+      height = MeasureSpec.getSize(h);
+    } else {
+      // Make the aspect ratio 1:1, but limit the height to fit on screen with some room to spare.
+      int screenHeight = getResources().getDisplayMetrics().heightPixels;
+      height = Math.min(width, (int)(0.8 * screenHeight));
+      if (hMode == MeasureSpec.AT_MOST) {
+        height = Math.min(height, MeasureSpec.getSize(h));
+      }
+    }
+
+    setMeasuredDimension(width, height);
+  }
+
+  @Override
   protected void onDraw(Canvas canvas) {
     super.onDraw(canvas);
     // Normally the coordinate system puts 0,0 at the top left.  This puts it at the bottom right,

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -42,39 +42,66 @@
     </FrameLayout>
   </LinearLayout>
 
-  <com.google.android.material.navigation.NavigationView
-      android:id="@+id/drawer"
-      android:layout_width="wrap_content"
-      android:layout_height="match_parent"
-      android:layout_gravity="start"
-      android:fitsSystemWindows="true"
-      app:menu="@menu/drawer_menu">
+  <!-- The NavigationView class supports a header, but not a footer.  To produce the desired footer
+  behavior, we use an outer NavigationView that has no menu, but contains a scrollview that
+  holds a constraint chain: the real navigation view, a spacer, and the footer elements. -->
+  <app.intra.PadNavigationView
+          android:id="@+id/outer_drawer"
+          android:layout_width="wrap_content"
+          android:layout_height="match_parent"
+          android:fitsSystemWindows="true"
+          android:layout_gravity="start">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:gravity="bottom"
-        android:orientation="vertical">
-      <TextView
-          android:id="@+id/credit_text_view"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_gravity="bottom"
-          android:layout_margin="16dp"
-          android:linksClickable="true"
-          android:text="@string/credits_text"
-          android:textAppearance="@style/TextAppearance.AppCompat.Caption"/>
+    <androidx.core.widget.NestedScrollView
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            android:scrollbars="vertical" android:fillViewport="true">
 
-      <ImageView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_gravity="bottom"
-          android:adjustViewBounds="true"
-          android:scaleType="fitEnd"
-          app:srcCompat="@drawable/logo_backdrop"/>
-    </LinearLayout>
+      <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent"
+                                                         android:layout_height="match_parent">
 
-  </com.google.android.material.navigation.NavigationView>
+        <com.google.android.material.navigation.NavigationView
+                android:id="@+id/drawer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="fill_vertical"
+                app:menu="@menu/drawer_menu"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/nav_space"/>
+
+        <Space
+                android:id="@+id/nav_space"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@id/drawer"
+                app:layout_constraintBottom_toTopOf="@id/credit_text_view"/>
+
+        <TextView
+                android:id="@+id/credit_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:linksClickable="true"
+                android:text="@string/credits_text"
+                app:layout_constraintTop_toBottomOf="@id/nav_space"
+                app:layout_constraintBottom_toTopOf="@id/nav_image"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"/>
+
+        <ImageView
+                android:id="@+id/nav_image"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:srcCompat="@drawable/logo_backdrop"
+                tools:ignore="ContentDescription"
+                android:scaleType="fitCenter"
+                app:layout_constraintTop_toBottomOf="@id/credit_text_view"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:adjustViewBounds="true"/>
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+  </app.intra.PadNavigationView>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/Android/app/src/main/res/layout/main_content.xml
+++ b/Android/app/src/main/res/layout/main_content.xml
@@ -72,8 +72,7 @@
     <app.intra.util.HistoryGraph
         android:id="@+id/graph"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintDimensionRatio="1:1"/>
+        android:layout_height="wrap_content"/>
   </androidx.constraintlayout.widget.ConstraintLayout>
 
   <View
@@ -169,7 +168,7 @@
           android:minLines="2"
           android:text="@string/queries_per_minute"
           app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toEndOf="@+id/numRequestsLabel"
+          app:layout_constraintStart_toEndOf="@+id/numRequests"
           app:layout_constraintTop_toBottomOf="@+id/qpm"/>
     </LinearLayout>
 


### PR DESCRIPTION
This includes three major changes
1. Restructure the drawer menu to put the footer below the menu,
   instead of behind it.
2. Save and restore state in the app exclusion setting to fix a
   crash on rotation while this dialog is open.
3. Change HistoryGraph's size calculation to ensure it fits on
   the screen.