### PR TITLE
Adjust messaging when DNS-over-TLS is enabled in P

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -15,12 +15,12 @@ android {
         }
     }
     compileSdkVersion 28
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId "app.intra"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 6
         versionName "0.0.5"
         vectorDrawables.useSupportLibrary = true

--- a/Android/app/src/main/java/app/intra/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/MainActivity.java
@@ -450,7 +450,7 @@ public class MainActivity extends AppCompatActivity
     return true;
   }
 
-  private String getSystemDnsServer() {
+  private LinkProperties getLinkProperties() {
     ConnectivityManager connectivityManager =
         (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -461,7 +461,15 @@ public class MainActivity extends AppCompatActivity
     if (activeNetwork == null) {
       return null;
     }
-    LinkProperties linkProperties = connectivityManager.getLinkProperties(activeNetwork);
+    return connectivityManager.getLinkProperties(activeNetwork);
+  }
+
+  private String getSystemDnsServer() {
+    if (Build.VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) {
+      // getDnsServers requires Lollipop or later.
+      return null;
+    }
+    LinkProperties linkProperties = getLinkProperties();
     if (linkProperties == null) {
       return null;
     }
@@ -470,6 +478,30 @@ public class MainActivity extends AppCompatActivity
       return address.getHostAddress();
     }
     return null;
+  }
+
+  private enum PrivateDnsMode { NONE, OPPORTUNISTIC, STRICT };
+
+  private PrivateDnsMode getPrivateDnsMode() {
+    if (Build.VERSION.SDK_INT < VERSION_CODES.P) {
+      // Private DNS was introduced in P.
+      return PrivateDnsMode.NONE;
+    }
+
+    LinkProperties linkProperties = getLinkProperties();
+    if (linkProperties == null) {
+      return PrivateDnsMode.NONE;
+    }
+
+    if (linkProperties.getPrivateDnsServerName() != null) {
+      return PrivateDnsMode.STRICT;
+    }
+
+    if (linkProperties.isPrivateDnsActive()) {
+      return PrivateDnsMode.OPPORTUNISTIC;
+    }
+
+    return PrivateDnsMode.NONE;
   }
 
   private boolean getVpnActive() {
@@ -526,10 +558,27 @@ public class MainActivity extends AppCompatActivity
     final TextView indicatorText = controlView.findViewById(R.id.indicator);
     int colorId = on ? R.color.accent_good : R.color.accent_bad;
     int color = ContextCompat.getColor(this, colorId);
-    int templateId = on ? R.string.dns_on : R.string.dns_off;
+
+    PrivateDnsMode privateDnsMode = PrivateDnsMode.NONE;
+    int templateId;
+    if (on) {
+      templateId = R.string.dns_on;
+    } else {
+      privateDnsMode = getPrivateDnsMode();
+      if (privateDnsMode == PrivateDnsMode.STRICT) {
+        templateId = R.string.dns_strict;
+      } else if (privateDnsMode == PrivateDnsMode.OPPORTUNISTIC) {
+        templateId = R.string.dns_opportunistic;
+      } else {
+        templateId = R.string.dns_off;
+      }
+    }
+
     final TextView osStatusText = controlView.findViewById(R.id.os_status);
     if (vpnActive) {
-      osStatusText.setText(R.string.vpn_active);
+      osStatusText.setText(R.string.vpn_explanation);
+    } else if (privateDnsMode == PrivateDnsMode.STRICT) {
+      osStatusText.setText(R.string.dns_strict_explanation);
     } else {
       osStatusText.setText("");
     }

--- a/Android/app/src/main/java/app/intra/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/MainActivity.java
@@ -480,7 +480,11 @@ public class MainActivity extends AppCompatActivity
     return null;
   }
 
-  private enum PrivateDnsMode { NONE, OPPORTUNISTIC, STRICT };
+  private enum PrivateDnsMode {
+    NONE,  // The setting is "Off" or "Opportunistic", and the DNS connection is not using TLS.
+    UPGRADED,  // The setting is "Opportunistic", and the DNS connection has upgraded to TLS.
+    STRICT  // The setting is "Strict".
+  };
 
   private PrivateDnsMode getPrivateDnsMode() {
     if (Build.VERSION.SDK_INT < VERSION_CODES.P) {
@@ -498,7 +502,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     if (linkProperties.isPrivateDnsActive()) {
-      return PrivateDnsMode.OPPORTUNISTIC;
+      return PrivateDnsMode.UPGRADED;
     }
 
     return PrivateDnsMode.NONE;
@@ -567,8 +571,8 @@ public class MainActivity extends AppCompatActivity
       privateDnsMode = getPrivateDnsMode();
       if (privateDnsMode == PrivateDnsMode.STRICT) {
         templateId = R.string.dns_strict;
-      } else if (privateDnsMode == PrivateDnsMode.OPPORTUNISTIC) {
-        templateId = R.string.dns_opportunistic;
+      } else if (privateDnsMode == PrivateDnsMode.UPGRADED) {
+        templateId = R.string.dns_upgraded;
       } else {
         templateId = R.string.dns_off;
       }

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -84,8 +84,18 @@
 
   <string name="dns_off"
           description="This is a large message at the top of the main screen.  It says 'Your DNS queries are
-      exposed', with the word 'exposed' highlighted in a scary color.">
+      exposed', with the word 'exposed' highlighted in a scary color.  'exposed' here means both 'visible to untrusted parties' and 'vulnerable to manipulation by untrusted parties'.">
     <![CDATA[Your DNS queries are <font color=\"#%06X\">exposed</font>]]>
+  </string>
+
+  <string name="dns_opportunistic"
+          description="This is similar to dns_off, but with the word 'exposed' replaced by 'vulnerable'.  This is shown when the user has weak protection that an attacker could disable.">
+    <![CDATA[Your DNS queries are <font color=\"#%06X\">vulnerable</font>]]>
+  </string>
+
+  <string name="dns_strict"
+          description="This is similar to dns_on, but the protection is being provided by the operating system, not by Intra.  It is not color-highlighted.">
+    Your DNS queries are OS-protected
   </string>
 
   <string name="enable_protection"
@@ -98,9 +108,14 @@
     disable
   </string>
 
-  <string name="vpn_active"
+  <string name="vpn_explanation"
           description="Warning text shown on the main screen before the user starts Intra">
     Intra has detected another VPN on your device.  That VPN will be disabled if you enable Intra.
+  </string>
+
+  <string name="dns_strict_explanation"
+          description="Explanation on the main screen for users who have Private DNS strict mode enabled at the OS level.">
+    Android Private DNS is enabled, so your DNS queries are protected by the operating system.  Enabling Intra will override this setting for some apps.
   </string>
 
   <string name="system_details"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -110,12 +110,14 @@
 
   <string name="vpn_explanation"
           description="Warning text shown on the main screen before the user starts Intra">
-    Intra has detected another VPN on your device.  That VPN will be disabled if you enable Intra.
+    Intra has detected another VPN on your device.  If you enable Intra, that VPN will be disabled,
+    and less of your network activity is likely to be protected.
   </string>
 
   <string name="dns_strict_explanation"
           description="Explanation on the main screen for users who have Private DNS strict mode enabled at the OS level.">
-    Android Private DNS is enabled, so your DNS queries are protected by the operating system.  Enabling Intra will override this setting for some apps.
+    Intra has detected that the Android Private DNS setting is enabled.  This means your DNS
+    queries are already protected, so there's no need to enable Intra.
   </string>
 
   <string name="system_details"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -88,7 +88,7 @@
     <![CDATA[Your DNS queries are <font color=\"#%06X\">exposed</font>]]>
   </string>
 
-  <string name="dns_opportunistic"
+  <string name="dns_upgraded"
           description="This is similar to dns_off, but with the word 'exposed' replaced by 'vulnerable'.  This is shown when the user has weak protection that an attacker could disable.">
     <![CDATA[Your DNS queries are <font color=\"#%06X\">vulnerable</font>]]>
   </string>


### PR DESCRIPTION
Claiming that queries are "exposed" when DNS-over-TLS is
enabled in strict mode is incorrect, and would be cause for
concern among advanced users on Android P.

Fixes #17 

@dalyk, please review API usage
@cjhenck, please review strings