### PR TITLE
Improve state transitions

### DIFF
--- a/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
+++ b/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
@@ -252,6 +252,10 @@ public class DnsResolverUdpToHttps extends Thread {
 
   private void sendResult(DnsTransaction transaction) {
     vpnService.recordTransaction(transaction);
+    // Update the connection state.  If the transaction succeeded, then the connection is working.
+    // If the transaction failed, then the connection is not working.
+    // If the transaction was canceled, then we don't have any new information about the status
+    // of the connection, so we don't send an update.
     DnsVpnController controller = DnsVpnController.getInstance();
     if (transaction.status == DnsTransaction.Status.COMPLETE) {
       controller.onConnectionStateChanged(vpnService, ServerConnection.State.WORKING);

--- a/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
+++ b/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
@@ -255,7 +255,7 @@ public class DnsResolverUdpToHttps extends Thread {
     DnsVpnController controller = DnsVpnController.getInstance();
     if (transaction.status == DnsTransaction.Status.COMPLETE) {
       controller.onConnectionStateChanged(vpnService, ServerConnection.State.WORKING);
-    } else {
+    } else if (transaction.status != DnsTransaction.Status.CANCELED) {
       controller.onConnectionStateChanged(vpnService, ServerConnection.State.FAILING);
     }
   }
@@ -285,7 +285,8 @@ public class DnsResolverUdpToHttps extends Thread {
 
     @Override
     public void onFailure(Call call, IOException e) {
-      transaction.status = DnsTransaction.Status.SEND_FAIL;
+      transaction.status = call.isCanceled() ?
+          DnsTransaction.Status.CANCELED : DnsTransaction.Status.SEND_FAIL;
       FirebaseCrash.logcat(Log.WARN, LOG_TAG, "Failed to read HTTPS response: " + e.toString());
       if (e instanceof SocketTimeoutException) {
         FirebaseCrash.logcat(Log.WARN, LOG_TAG, "Workaround for OkHttp3 #3146: resetting");

--- a/Android/app/src/main/java/app/intra/DnsVpnController.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnController.java
@@ -71,6 +71,9 @@ public class DnsVpnController {
   }
 
   public synchronized void start(Context context) {
+    if (dnsVpnService != null) {
+      return;
+    }
     PersistentState.setVpnEnabled(context, true);
     stateChanged(context);
     Intent startServiceIntent = new Intent(context, DnsVpnService.class);

--- a/Android/app/src/main/java/app/intra/util/DnsTransaction.java
+++ b/Android/app/src/main/java/app/intra/util/DnsTransaction.java
@@ -28,7 +28,8 @@ public class DnsTransaction implements Serializable {
     SEND_FAIL,
     HTTP_ERROR,
     BAD_RESPONSE,
-    INTERNAL_ERROR
+    INTERNAL_ERROR,
+    CANCELED
   }
 
   public DnsTransaction(DnsUdpQuery query) {


### PR DESCRIPTION
This change bundles four improvements to transitions between states:

1. Restarting the VPN is now seamless, whereas previously it
   caused the VPN to pass through the unprotected state.
2. Queries that were canceled are no longer counted as failing.
3. Resetting a connection now performs a deeper reset.  This appears
   to be more reliable and should not be any slower.
4. DnsVpnController.start() is now idempotent, to ensure that we
   avoid double-starts.