### PR TITLE
Show a symbol if we don't have a flag

### DIFF
--- a/Android/app/src/main/java/app/intra/RecyclerAdapter.java
+++ b/Android/app/src/main/java/app/intra/RecyclerAdapter.java
@@ -219,10 +219,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         resolver = transaction.serverIp;
       }
 
-      if (transaction.status != DnsTransaction.Status.COMPLETE) {
-        response = transaction.status.name();
-        flag = "";
-      } else {
+      if (transaction.status == DnsTransaction.Status.COMPLETE) {
         DnsPacket packet = null;
         String err = null;
         try {
@@ -239,11 +236,18 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             flag = getFlag(countryCode);
           } else {
             response = "NXDOMAIN";
-            flag = "";
+            flag = "\u2754";  // White question mark
           }
         } else {
           response = err;
-          flag = "";
+          flag = "\u26a0";  // Warning sign
+        }
+      } else {
+        response = transaction.status.name();
+        if (transaction.status == DnsTransaction.Status.CANCELED) {
+          flag = "\u274c";  // "X" mark
+        } else {
+          flag = "\u26a0";  // Warning sign
         }
       }
     }


### PR DESCRIPTION
Currently, rows without a flag (most commonly NXDOMAIN)
just have a blank where the flag should be.  This is not
very appealing, and doesn't distinguish between different
kinds of errors.