### PR TITLE
Reintroduce Play Store exclusion

### DIFF
--- a/Android/app/src/main/java/app/intra/DnsVpnService.java
+++ b/Android/app/src/main/java/app/intra/DnsVpnService.java
@@ -371,6 +371,8 @@ public class DnsVpnService extends VpnService implements NetworkManager.NetworkL
         for (String packageName : PersistentState.getExcludedPackages(this)) {
           builder = builder.addDisallowedApplication(packageName);
         }
+        // Play Store incompatibility is a known issue, so always exclude it.
+        builder = builder.addDisallowedApplication("com.android.vending");
       } catch (PackageManager.NameNotFoundException e) {
         FirebaseCrash.report(e);
         Log.e(LOG_TAG, "Failed to exclude an app", e);


### PR DESCRIPTION
Users have reported a bad interaction with the Play Store's
option to download only over Wi-Fi, and there's no obvious
benefit to including the Play Store in Intra's scope.