### PR TITLE
Fix a crash in sockslib's StreamPipe

### DIFF
--- a/Android/third_party/sockslib/src/main/java/sockslib/server/io/StreamPipe.java
+++ b/Android/third_party/sockslib/src/main/java/sockslib/server/io/StreamPipe.java
@@ -120,7 +120,7 @@ public class StreamPipe implements Runnable, Pipe {
       runningThread = new Thread(this);
       runningThread.setDaemon(daemon);
       runningThread.start();
-      for (PipeListener listener : pipeListeners) {
+      for (PipeListener listener : new ArrayList<>(pipeListeners)) {
         listener.onStart(this);
       }
       return true;
@@ -136,8 +136,7 @@ public class StreamPipe implements Runnable, Pipe {
       if (runningThread != null) {
         runningThread.interrupt();
       }
-      for (int i = 0; i < pipeListeners.size(); i++) {
-        PipeListener listener = pipeListeners.get(i);
+      for (PipeListener listener : new ArrayList<>(pipeListeners)) {
         listener.onStop(this);
       }
       return true;
@@ -170,14 +169,14 @@ public class StreamPipe implements Runnable, Pipe {
       if (length > 0) { // transfer the buffer destination output stream.
         destination.write(buffer, 0, length);
         destination.flush();
-        for (int i = 0; i < pipeListeners.size(); i++) {
-          pipeListeners.get(i).onTransfer(this, buffer, length);
+        for (PipeListener listener : new ArrayList<>(pipeListeners)) {
+          listener.onTransfer(this, buffer, length);
         }
       }
 
     } catch (IOException e) {
-      for (int i = 0; i < pipeListeners.size(); i++) {
-        pipeListeners.get(i).onError(this, e);
+      for (PipeListener listener : new ArrayList<>(pipeListeners)) {
+        listener.onError(this, e);
       }
       stop();
     }


### PR DESCRIPTION
We've seen several crash reports from users related to this issue.
The crash is an IndexOutOfRangeException in StreamPipe.doTransfer.
It occurs because the list of listeners is modified during iteration,
so the iteration runs past the end of the list.

This pattern appears throughout StreamPipe.  This change resolves the
problem by making a shallow copy of pipeListeners before iterating
through the list.

TODO: Upstream into sockslib.