### PR TITLE
Fix "ghost scroll" when switching modes

### DIFF
--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -183,6 +183,7 @@
                         android:scrollbars="horizontal"
                         android:singleLine="true"
                         android:textIsSelectable="true"
+                        android:focusable="false"
                         android:text="dns.google.com"
                         android:textAppearance="@style/TextAppearance.AppCompat.Large"/>
 
@@ -274,6 +275,7 @@
                     android:text="@string/unknown_server"
                     android:textAppearance="@style/TextAppearance.AppCompat.Large"
                     android:textIsSelectable="true"
+                    android:focusable="false"
                     tools:text="very:long:addr:goes:here"/>
 
             <TextView


### PR DESCRIPTION
Previously, the entire main view would scroll down
to the nearest focusable TextView every time the
user toggles the activation state.