### PR TITLE
Fix a crash when receiving an empty DNS response

### DIFF
--- a/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
+++ b/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.SocketTimeoutException;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
 import app.intra.util.DnsUdpQuery;
@@ -87,9 +88,14 @@ class DnsResolverUdpToHttps {
     }
 
     // Writes |dnsRequestId| to |dnsResponse|'s ID header.
-    private void writeRequestIdToDnsResponse(byte[] dnsResponse, short dnsRequestId) {
+    private boolean writeRequestIdToDnsResponse(byte[] dnsResponse, short dnsRequestId) {
       ByteBuffer buffer = ByteBuffer.wrap(dnsResponse);
-      buffer.putShort(dnsRequestId);
+      try {
+        buffer.putShort(dnsRequestId);
+        return true;
+      } catch (BufferOverflowException e) {
+        return false;
+      }
     }
 
     private void sendResult() {
@@ -113,12 +119,11 @@ class DnsResolverUdpToHttps {
       sendResult();
     }
 
-    @Override
-    public void onResponse(Call call, Response response) {
+    // Populate |transaction| from the headers and body of |response|.
+    private void processResponse(Response response) {
       transaction.serverIp = response.header(IpTagInterceptor.HEADER_NAME);
       if (!response.isSuccessful()) {
         transaction.status = DnsTransaction.Status.HTTP_ERROR;
-        sendResult();
         return;
       }
       byte[] dnsResponse;
@@ -126,24 +131,30 @@ class DnsResolverUdpToHttps {
         dnsResponse = response.body().bytes();
       } catch (IOException e) {
         transaction.status = DnsTransaction.Status.BAD_RESPONSE;
-        sendResult();
         return;
       }
-      writeRequestIdToDnsResponse(dnsResponse, dnsUdpQuery.requestId);
+      if (!writeRequestIdToDnsResponse(dnsResponse, dnsUdpQuery.requestId)) {
+        FirebaseCrash.logcat(Log.WARN, LOG_TAG, "ID replacement failed");
+        transaction.status = DnsTransaction.Status.BAD_RESPONSE;
+        return;
+      }
       DnsUdpQuery parsedDnsResponse = DnsUdpQuery.fromUdpBody(dnsResponse);
       if (parsedDnsResponse != null) {
         Log.d(LOG_TAG, "RNAME: " + parsedDnsResponse.name + " NAME: " + dnsUdpQuery.name);
         if (!dnsUdpQuery.name.equals(parsedDnsResponse.name)) {
           FirebaseCrash.logcat(Log.ERROR, LOG_TAG, "Mismatch in request and response names.");
           transaction.status = DnsTransaction.Status.BAD_RESPONSE;
-          sendResult();
           return;
         }
       }
 
       transaction.status = DnsTransaction.Status.COMPLETE;
       transaction.response = dnsResponse;
+    }
 
+    @Override
+    public void onResponse(Call call, Response response) {
+      processResponse(response);
       sendResult();
     }
   }

--- a/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
+++ b/Android/app/src/main/java/app/intra/DnsResolverUdpToHttps.java
@@ -88,14 +88,10 @@ class DnsResolverUdpToHttps {
     }
 
     // Writes |dnsRequestId| to |dnsResponse|'s ID header.
-    private boolean writeRequestIdToDnsResponse(byte[] dnsResponse, short dnsRequestId) {
+    private void writeRequestIdToDnsResponse(byte[] dnsResponse, short dnsRequestId)
+        throws BufferOverflowException {
       ByteBuffer buffer = ByteBuffer.wrap(dnsResponse);
-      try {
-        buffer.putShort(dnsRequestId);
-        return true;
-      } catch (BufferOverflowException e) {
-        return false;
-      }
+      buffer.putShort(dnsRequestId);
     }
 
     private void sendResult() {
@@ -133,7 +129,9 @@ class DnsResolverUdpToHttps {
         transaction.status = DnsTransaction.Status.BAD_RESPONSE;
         return;
       }
-      if (!writeRequestIdToDnsResponse(dnsResponse, dnsUdpQuery.requestId)) {
+      try {
+        writeRequestIdToDnsResponse(dnsResponse, dnsUdpQuery.requestId);
+      } catch (BufferOverflowException e) {
         FirebaseCrash.logcat(Log.WARN, LOG_TAG, "ID replacement failed");
         transaction.status = DnsTransaction.Status.BAD_RESPONSE;
         return;


### PR DESCRIPTION
Currently, if the server sends a successful HTTP response
with an empty body, Intra will try to rewrite the first two
bytes (which don't exist), resulting in a BufferOverflowException.

This change also includes a small refactor for clarity.