### PR TITLE
Remove all polling from the SOCKS server

### DIFF
--- a/Android/app/src/main/java/app/intra/socks/SocksServer.java
+++ b/Android/app/src/main/java/app/intra/socks/SocksServer.java
@@ -18,6 +18,10 @@ import sockslib.server.SocksHandler;
 public class SocksServer extends BasicSocksProxyServer {
   private static final String LOG_TAG = "SocksServer";
 
+  // RFC 5382 REQ-5 requires a timeout no shorter than 2 hours and 4 minutes.
+  // Sockslib's default is 10 seconds.
+  private static final int TIMEOUT_MS = 1000 * 60 * (4 + 60 * 2);
+
   private final InetSocketAddress fakeDns;
   private final InetSocketAddress trueDns;
 
@@ -25,6 +29,7 @@ public class SocksServer extends BasicSocksProxyServer {
     super(UdpOverrideSocksHandler.class);
     this.fakeDns = fakeDns;
     this.trueDns = trueDns;
+    setTimeout(TIMEOUT_MS);
   }
 
   @Override

--- a/Android/third_party/sockslib/src/main/java/sockslib/server/Socks5Handler.java
+++ b/Android/third_party/sockslib/src/main/java/sockslib/server/Socks5Handler.java
@@ -14,6 +14,7 @@
 
 package sockslib.server;
 
+import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sockslib.client.SocksProxy;
@@ -66,8 +67,6 @@ public class Socks5Handler implements SocksHandler {
   private MethodSelector methodSelector;
 
   private int bufferSize;
-
-  private int idleTime = 2000;
 
   private SocksProxy proxy;
 
@@ -182,19 +181,50 @@ public class Socks5Handler implements SocksHandler {
     if(getSocksProxyServer().getPipeInitializer() != null){
       pipe = getSocksProxyServer().getPipeInitializer().initialize(pipe);
     }
-    pipe.start(); // This method will build tow thread to run tow internal pipes.
 
     // wait for pipe exit.
-    while (pipe.isRunning()) {
-      try {
-        Thread.sleep(idleTime);
-      } catch (InterruptedException e) {
-        pipe.stop();
-        session.close();
-        logger.info("SESSION[{}] closed", session.getId());
-      }
+    try {
+      runPipe(pipe);
+    } catch (InterruptedException e) {
+      pipe.stop();
+      session.close();
+      logger.info("SESSION[{}] closed", session.getId());
     }
+  }
 
+  /**
+   * This function starts the pipe and blocks until the pipe stops.
+   * @param pipe A pipe that has not yet been started.
+   * @throws InterruptedException if this thread is interrupted.
+   */
+  private static void runPipe(final Pipe pipe) throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    pipe.addPipeListener(new PipeListener() {
+      @Override
+      public void onStart(Pipe pipe) {
+
+      }
+
+      @Override
+      public void onStop(Pipe pipe) {
+        latch.countDown();
+      }
+
+      @Override
+      public void onTransfer(Pipe pipe, byte[] buffer, int bufferLength) {
+
+      }
+
+      @Override
+      public void onError(Pipe pipe, Exception exception) {
+
+      }
+    });
+
+    pipe.start(); // This method will build two threads to run two internal pipes.
+    while (pipe.isRunning()) {
+      latch.await();
+    }
   }
 
   @Override
@@ -215,17 +245,14 @@ public class Socks5Handler implements SocksHandler {
 
     Pipe pipe = new SocketPipe(session.getSocket(), socket);
     pipe.setBufferSize(bufferSize);
-    pipe.start();
 
     // wait for pipe exit.
-    while (pipe.isRunning()) {
-      try {
-        Thread.sleep(idleTime);
-      } catch (InterruptedException e) {
-        pipe.stop();
-        session.close();
-        logger.info("Session[{}] closed", session.getId());
-      }
+    try {
+      runPipe(pipe);
+    } catch (InterruptedException e) {
+      pipe.stop();
+      session.close();
+      logger.info("Session[{}] closed", session.getId());
     }
     serverSocket.close();
     // throw new NotImplementException("Not implement BIND command");
@@ -242,20 +269,21 @@ public class Socks5Handler implements SocksHandler {
         .getSocketAddress());
     session.write(new CommandResponseMessage(VERSION, ServerReply.SUCCEEDED, InetAddress
         .getLocalHost(), socketAddress.getPort()));
-    while (udpRelayServer.isRunning()) {
-      try {
-        Thread.sleep(idleTime);
-      } catch (InterruptedException e) {
-        session.close();
-        logger.info("Session[{}] closed", session.getId());
+    try {
+      // The client should never send any more data on the control socket, so read() should hang
+      // until the client closes the socket (returning -1) or this thread is interrupted (throwing
+      // InterruptedIOException).
+      int nextByte = session.getInputStream().read();
+      if (nextByte != -1) {
+        logger.warn("Unexpected data on Session[{}]", session.getId());
       }
-      if (session.isClose()) {
-        udpRelayServer.stop();
-        logger.debug("UDP relay server for session[{}] is closed", session.getId());
-      }
-
+    } catch (IOException e) {
+      // This is expected on a thread interrupt.
     }
-
+    session.close();
+    logger.info("Session[{}] closed", session.getId());
+    udpRelayServer.stop();
+    logger.debug("UDP relay server for session[{}] is closed", session.getId());
   }
 
   @Override
@@ -297,17 +325,6 @@ public class Socks5Handler implements SocksHandler {
   @Override
   public void setBufferSize(int bufferSize) {
     this.bufferSize = bufferSize;
-  }
-
-
-  @Override
-  public int getIdleTime() {
-    return idleTime;
-  }
-
-  @Override
-  public void setIdleTime(int idleTime) {
-    this.idleTime = idleTime;
   }
 
   public SocksProxy getProxy() {

--- a/Android/third_party/sockslib/src/main/java/sockslib/server/SocksHandler.java
+++ b/Android/third_party/sockslib/src/main/java/sockslib/server/SocksHandler.java
@@ -103,20 +103,6 @@ public interface SocksHandler extends Runnable {
    */
   void setBufferSize(int bufferSize);
 
-  /**
-   * Returns idle time.
-   *
-   * @return idle time.
-   */
-  int getIdleTime();
-
-  /**
-   * Sets idle time.
-   *
-   * @param idleTime Idle time.
-   */
-  void setIdleTime(int idleTime);
-
   void setProxy(SocksProxy socksProxy);
 
   SocksProxyServer getSocksProxyServer();

--- a/Android/third_party/sockslib/src/main/java/sockslib/server/io/SocketPipe.java
+++ b/Android/third_party/sockslib/src/main/java/sockslib/server/io/SocketPipe.java
@@ -110,11 +110,10 @@ public class SocketPipe implements Pipe {
   @Override
   public boolean stop() {
     if (running) {
+      // Ensure that isRunning() returns false when PipeListener.onStop() runs.
+      running = false;
       pipe1.stop();
       pipe2.stop();
-      if (!pipe1.isRunning() && !pipe2.isRunning()) {
-        running = false;
-      }
     }
     return running;
   }


### PR DESCRIPTION
This change also essentially removes the socket idle timeout,
which is much less necessary now that idle sockets don't
consume CPU time.

Fixes #113