### PR TITLE
Fix autostart-on-boot and autostart-on-launch

### DIFF
--- a/Android/app/src/main/java/app/intra/AutoStarter.java
+++ b/Android/app/src/main/java/app/intra/AutoStarter.java
@@ -23,7 +23,10 @@ public class AutoStarter extends BroadcastReceiver {
       FirebaseCrash.logcat(Log.DEBUG, LOG_TAG, "Autostart enabled");
       if (VpnService.prepare(context) != null) {
         // prepare() returns a non-null intent if VPN permission has not been granted.
-        FirebaseCrash.logcat(Log.WARN, LOG_TAG, "VPN permission not granted");
+        FirebaseCrash.logcat(Log.WARN, LOG_TAG, "VPN permission not granted.  Starting UI.");
+        Intent startIntent = new Intent(context, MainActivity.class);
+        startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(startIntent);
         return;
       }
       controller.start(context);

--- a/Android/app/src/main/java/app/intra/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/MainActivity.java
@@ -374,8 +374,8 @@ public class MainActivity extends AppCompatActivity
     DnsVpnController controller = DnsVpnController.getInstance();
     DnsVpnState state = controller.getState(this);
     if (state.activationRequested && !state.on) {
-      FirebaseCrash.logcat(Log.INFO, LOG_TAG, "Autostarting");
-      controller.start(this);
+      FirebaseCrash.logcat(Log.INFO, LOG_TAG, "Autostart enabled");
+      prepareAndStartDnsVpn();
     }
   }
 

--- a/Android/app/src/main/java/app/intra/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/MainActivity.java
@@ -523,8 +523,12 @@ public class MainActivity extends AppCompatActivity
 
   @Override
   public void onActivityResult(int request, int result, Intent data) {
-    if (request == REQUEST_CODE_PREPARE_VPN && result == RESULT_OK) {
-      startDnsVpnService();
+    if (request == REQUEST_CODE_PREPARE_VPN) {
+      if (result == RESULT_OK) {
+        startDnsVpnService();
+      } else {
+        stopDnsVpnService();
+      }
     }
   }
 


### PR DESCRIPTION
Previously, autostart-on-launch would never call VpnService.prepare,
and autostart-on-boot would fail if VPN permission had been lost.
The former is a problem when the user launches Intra before autostart
completes, and the latter is a problem on older devices that reset
the VPN permission on reboot.

This change fixes autostart-on-launch, and makes autostart-on-boot
launch the app if VPN permission has been lost, so that the user
can re-permission Intra.

Fixes #105