### PR TITLE
Add info pages for each of the detailed info tiles

### DIFF
--- a/Android/app/src/main/java/app/intra/ui/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/ui/MainActivity.java
@@ -254,7 +254,6 @@ public class MainActivity extends AppCompatActivity
 
     // Set up the main UI
     final Switch switchButton = controlView.findViewById(R.id.dns_switch);
-    syncDnsStatus();
     switchButton.setOnCheckedChangeListener(
         new CompoundButton.OnCheckedChangeListener() {
           @Override
@@ -297,6 +296,7 @@ public class MainActivity extends AppCompatActivity
     showNumRequests(numRequests);
 
     updateServerName();
+    syncDnsStatus();
 
     // Start updating the live Queries Per Minute value.
     startAnimation();
@@ -664,6 +664,9 @@ public class MainActivity extends AppCompatActivity
 
       ImageView defaultServerIcon = controlView.findViewById(R.id.default_server_icon);
       defaultServerIcon.setColorFilter(color, Mode.SRC_ATOP);
+
+      setInfoClicker(R.id.default_server_box, privateDnsMode == PrivateDnsMode.STRICT ?
+          InfoPage.STRICT_MODE_SERVER : InfoPage.DEFAULT_SERVER);
       }
   }
 
@@ -769,10 +772,15 @@ public class MainActivity extends AppCompatActivity
         R.string.status_strict,
         R.string.explanation_strict),
     DEFAULT_SERVER(false,
-        R.string.insecure_server_label,
+        R.string.default_server_label,
         R.drawable.ic_server,
         R.string.insecure_server_headline,
-        R.string.insecure_server_body);
+        R.string.insecure_server_body),
+    STRICT_MODE_SERVER(true,
+        R.string.default_server_label,
+        R.drawable.ic_server,
+        R.string.strict_mode_server_headline,
+        R.string.strict_mode_server_body);
 
     final boolean good;
     final @StringRes int title;

--- a/Android/app/src/main/java/app/intra/ui/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/ui/MainActivity.java
@@ -614,6 +614,10 @@ public class MainActivity extends AppCompatActivity
     View insecureSystemDetails = controlView.findViewById(R.id.insecure_system_details);
     insecureSystemDetails.setVisibility(status.on ? View.GONE : View.VISIBLE);
     if (!status.on) {
+      TextView defaultProtocol = controlView.findViewById(R.id.default_protocol);
+      boolean tls = privateDnsMode != PrivateDnsMode.NONE;
+      defaultProtocol.setText(tls ? R.string.tls_transport : R.string.insecure_transport);
+
       String insecureServerAddress = getSystemDnsServer();
       if (insecureServerAddress == null) {
         insecureServerAddress = getResources().getText(R.string.unknown_server).toString();

--- a/Android/app/src/main/java/app/intra/ui/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/ui/MainActivity.java
@@ -625,7 +625,7 @@ public class MainActivity extends AppCompatActivity
     View insecureSystemDetails = controlView.findViewById(R.id.insecure_system_details);
     insecureSystemDetails.setVisibility(status.on ? View.GONE : View.VISIBLE);
     if (!status.on) {
-      TextView defaultProtocol = controlView.findViewById(R.id.insecure_protocol);
+      TextView defaultProtocol = controlView.findViewById(R.id.default_protocol);
       boolean tls = privateDnsMode != PrivateDnsMode.NONE;
       defaultProtocol.setText(tls ? R.string.tls_transport : R.string.insecure_transport);
 

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -34,6 +34,11 @@
           android:id="@+id/settings"
           layout="@layout/placeholder"
           android:visibility="gone"/>
+
+      <include
+          android:id="@+id/info_page"
+          layout="@layout/info_page"
+          android:visibility="gone"/>
     </FrameLayout>
   </LinearLayout>
 

--- a/Android/app/src/main/res/layout/info_page.xml
+++ b/Android/app/src/main/res/layout/info_page.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="32dp"
+    android:orientation="vertical">
+  <androidx.legacy.widget.Space
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"/>
+  <ImageView
+      android:id="@+id/info_image"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      tools:ignore="ContentDescription"
+      tools:src="@drawable/ic_lock_black_24dp"
+      tools:tint="@color/accent_good"/>
+  <TextView
+      android:id="@+id/info_headline"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingTop="16dp"
+      android:paddingBottom="16dp"
+      android:textAppearance="@style/TextAppearance.AppCompat.Large"
+      tools:text="@string/transport_headline"/>
+  <TextView
+      android:id="@+id/info_body"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small"
+      tools:text="@string/transport_body"/>
+  <androidx.legacy.widget.Space
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"/>
+</LinearLayout>

--- a/Android/app/src/main/res/layout/intro_page.xml
+++ b/Android/app/src/main/res/layout/intro_page.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
               xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent" android:gravity="center"

--- a/Android/app/src/main/res/layout/main_content.xml
+++ b/Android/app/src/main/res/layout/main_content.xml
@@ -40,7 +40,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/dns_switch"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="On" android:textColor="@color/indicator"/>
+            tools:text="@string/indicator_on"
+            android:textColor="@color/indicator"/>
 
     <Switch
             android:id="@+id/dns_switch" android:layout_width="wrap_content"
@@ -57,16 +58,22 @@
 
     <TextView
             android:id="@+id/status"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
             android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
             android:includeFontPadding="false"
             android:textAppearance="@style/Biggest"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/indicator"
             app:layout_constraintBottom_toTopOf="@id/explanation"
-            tools:text="Protected" android:textColor="@color/accent_good"/>
+            app:layout_constraintWidth_default="wrap"
+            tools:text="@string/status_protected"
+            android:textColor="@color/accent_good"/>
 
     <TextView
             android:id="@+id/explanation"

--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -203,7 +203,7 @@
             android:layout_height="wrap_content">
 
         <LinearLayout
-                android:id="@+id/insecure_protocol_box"
+                android:id="@+id/default_protocol_box"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:padding="16dp"
@@ -228,9 +228,10 @@
                     tools:ignore="ContentDescription"/>
 
             <TextView
+                    android:id="@+id/default_protocol"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="dns"
+                    tools:text="@string/insecure_transport"
                     android:textAppearance="@style/TextAppearance.AppCompat.Large"/>
 
             <TextView
@@ -253,7 +254,7 @@
                 android:orientation="vertical"
                 android:background="@color/floating"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/insecure_protocol_box"
+                app:layout_constraintStart_toEndOf="@+id/default_protocol_box"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent">
 

--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -203,7 +203,7 @@
             android:layout_height="wrap_content">
 
         <LinearLayout
-                android:id="@+id/insecure_protocol_box"
+                android:id="@+id/default_protocol_box"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:padding="16dp"
@@ -228,7 +228,7 @@
                     tools:ignore="ContentDescription"/>
 
             <TextView
-                    android:id="@+id/insecure_protocol"
+                    android:id="@+id/default_protocol"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="@string/insecure_transport"
@@ -254,7 +254,7 @@
                 android:orientation="vertical"
                 android:background="@color/floating"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/insecure_protocol_box"
+                app:layout_constraintStart_toEndOf="@+id/default_protocol_box"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent">
 

--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -203,7 +203,7 @@
             android:layout_height="wrap_content">
 
         <LinearLayout
-                android:id="@+id/default_protocol_box"
+                android:id="@+id/insecure_protocol_box"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:padding="16dp"
@@ -228,7 +228,7 @@
                     tools:ignore="ContentDescription"/>
 
             <TextView
-                    android:id="@+id/default_protocol"
+                    android:id="@+id/insecure_protocol"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="@string/insecure_transport"
@@ -254,7 +254,7 @@
                 android:orientation="vertical"
                 android:background="@color/floating"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/default_protocol_box"
+                app:layout_constraintStart_toEndOf="@+id/insecure_protocol_box"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent">
 

--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -285,7 +285,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:minLines="2"
-                    android:text="@string/insecure_server_label"/>
+                    android:text="@string/default_server_label"/>
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Android/app/src/main/res/layout/system_details.xml
+++ b/Android/app/src/main/res/layout/system_details.xml
@@ -214,12 +214,13 @@
                 android:layout_marginTop="32dp"
                 android:orientation="vertical"
                 android:background="@color/floating"
-                app:layout_constraintEnd_toStartOf="@+id/insecure_server_box"
+                app:layout_constraintEnd_toStartOf="@+id/default_server_box"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent">
 
             <ImageView
+                    android:id="@+id/default_protocol_icon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="64dp"
@@ -238,11 +239,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:minLines="2"
-                    android:text="@string/insecure_transport_label"/>
+                    android:text="@string/default_transport_label"/>
         </LinearLayout>
 
         <LinearLayout
-                android:id="@+id/insecure_server_box"
+                android:id="@+id/default_server_box"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:padding="16dp"
@@ -259,6 +260,7 @@
                 app:layout_constraintBottom_toBottomOf="parent">
 
             <ImageView
+                    android:id="@+id/default_server_icon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="64dp"
@@ -267,7 +269,7 @@
                     tools:ignore="ContentDescription"/>
 
             <TextView
-                    android:id="@+id/insecure_server_value"
+                    android:id="@+id/default_server_value"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:ellipsize="none"

--- a/Android/app/src/main/res/values-ar/strings.xml
+++ b/Android/app/src/main/res/values-ar/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">مسار أكثر أمانًا لمزيد من الحماية للإنترنت المفتوح</string>
-  <string name="intro_benefit_body">عند استخدام الإنترنت، يبحث جهازك عن العناوين في إحدى قوائم جهات الاتصال على الإنترنت. وفي بعض الأحيان، قد ينتُج عن الاتصال عنوان خاطئ.</string>
-  <string name="intro_manipulation_headline">الحماية من العناوين الخاطئة</string>
-  <string name="intro_manipulation_body">تحميك أداة Intra من الوصول إلى عناوين خاطئة تؤدي إلى نهايات مُغلقة (التلاعب بنظام أسماء النطاقات)، وذلك من خلال تشفير اتصالك بنظام أسماء النطاقات.</string>
-  <string name="intro_details_headline">تحتاج أداة Intra مراقبة حركة بيانات الشبكة من أجل تفعيل الحماية</string>
-  <string name="intro_details_body">انقر على \"موافق\" عند رؤية طلب الاتصال للبدء. سيتم توجيه طلبات بحثك تلقائيًا إلى \"نظام أسماء النطاقات العام من Google\" (<a href="https://developers.google.com/speed/public-dns/privacy">سياسة الخصوصية</a>). ويمكنك اختيار خدمة أخرى من إعدادات التطبيق.</string>
+  <string name="intro_benefit_headline">اتصال أكثر أمانًا بالإنترنت</string>
+  <string name="intro_benefit_body">تحمي أداة Intra اتصالك من التلاعب بنظام أسماء النطاقات، وفيه تُستخدَم هجمة إلكترونية لحظر الوصول إلى مواقع الأخبار ومنصَّات وسائل التواصل الاجتماعي وتطبيقات المُراسلة.\n\nوعلى الرغم من قدرة Intra على حمايتك من التلاعب بنظام أسماء النطاقات، توجد أساليب وهَجَمات أكثر تعقيدًا للحظر لا تستطيع Intra حماية اتصالك منها.</string>
+  <string name="intro_manipulation_headline">الحماية من التلاعب بنظام أسماء النطاقات</string>
+  <string name="intro_manipulation_body">تحمي Intra اتصالك بنظام أسماء النطاقات (DNS) الذي يمنحك العناوين الدقيقة التي تحتاج إليها لزيارة موقع إلكتروني محدَّد أو فتح أحد التطبيقات.\n\nتستخدم هذه الأداة ميزة التشفير لضمان عدم التلاعب بالنتائج، مما يساعدك على الاتصال بالإنترنت بأمان.</string>
+  <string name="intro_details_headline">هناك شيء أخير…</string>
+  <string name="intro_details_body">انقر على \"موافق\" للسماح لأداة Intra بحماية طلبات بحث نظام أسماء النطاقات لديك. سيتم توجيه هذه الطلبات تلقائيًا إلى \"نظام أسماء النطاقات العام من Google\" (<a href="https://developers.google.com/speed/public-dns/privacy">سياسة الخصوصية</a>). ويمكنك اختيار خدمة أخرى من إعدادات التطبيق.</string>
   <string name="intro_back">السابق</string>
   <string name="intro_next">التالي</string>
   <string name="intro_accept">قبول</string>
-  <string name="about_headline">نظام أسماء نطاقات موثوق وآمن</string>
-  <string name="about_text">تحمي أداة Intra طلبات نظام أسماء النطاقات من خلال توجيهها عبر اتصال HTTPS آمن. ويؤدي ذلك إلى
-    تقليل احتمال انتقالك إلى موقع إلكتروني خطأ أو حظر ما تتصفّحه أو مراقبته.</string>
-  <string name="privacy_text">سيتم توجيه طلبات البحث بشكلٍ تلقائي إلى
-    <a href="https://developers.google.com/speed/public-dns/">نظام أسماء النطاقات العام من Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">سياسة الخصوصية</a>).
-    يمكنك أيضًا اختيار استخدام خدمة <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">سياسة الخصوصية</a>)
-    أو أي خدمة أخرى لنظام أسماء النطاقات على بروتوكول HTTPS.</string>
-  <string name="accept">البدء</string>
   <string name="drawer_open">فتح لائحة التنقّل</string>
   <string name="drawer_close">إغلاق لائحة التنقّل</string>
   <string name="home">الشاشة الرئيسية</string>
   <string name="settings">الإعدادات</string>
-  <string name="feedback">إرسال ملاحظات</string>
   <string name="support">الدعم</string>
   <string name="privacy_link">سياسة الخصوصية</string>
   <string name="tos_link">بنود الخدمة</string>
   <string name="source_code">رمز المصدر</string>
-  <string name="short_credits_text">أداة Intra مشروع تجريبي مفتوح المصدر مُقدَّم من <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">أنشأت <a href="https://jigsaw.google.com">Jigsaw</a> أداة Intra. وتستند مواقع IP إلى البيانات المأخوذة
 
     من DB-IP.com.</string>
@@ -52,11 +40,29 @@
   <string name="explanation_failing">تحذير: يتعذّر إجراء طلبات البحث. يمكنك اختيار خادم مختلف وإعادة تشغيل Intra.</string>
   <string name="system_details">تفاصيل النظام</string>
   <string name="num_requests">الطلبات حتى الآن</string>
+  <string name="num_requests_headline">يتم تنفيذ طلبات بحث نظام أسماء النطاقات عند بحث جهازك عن عنوان IP لاسم أحد النطاقات</string>
+  <string name="num_requests_body">تعرِض هذه القيمة إجمالي عدد طلبات بحث نظام أسماء النطاقات التي نفَّذها جهازك أثناء نشاط أداة Intra. وتعمل الأداة على تشفير طلبات البحث المعنية وإرسالها إلى خادِم موثوق به للتأكُّد من حصولك على نتائج حقيقية.</string>
   <string name="queries_per_minute">الطلبات الحديثة</string>
+  <string name="queries_per_minute_headline">تنفيذ طلبات بحث نظام أسماء النطاقات في بداية كل اتصال</string>
+  <string name="queries_per_minute_body">تعرِض هذه القيمة عدد طلبات بحث نظام أسماء النطاقات التي نفَّذها جهازك في الدقيقة الأخيرة. قد يتطلّب تحميل صفحة ويب معقّدة أكثر من مئة طلب بحث لنظام أسماء النطاقات.</string>
   <string name="transport_label">النقل المشفر</string>
-  <string name="insecure_transport_label">النقل غير المشفر</string>
+  <string name="transport_headline">التشفير يحمي طلبات بحثك من المتطفّلين</string>
+  <string name="transport_body">عندما تستخدم Intra، يتم تشفير طلبات بحث نظام أسماء النطاقات، بحيث تتمكّن أنت وخادِم نظام أسماء النطاقات فقط من الاطلّاع على طلبات بحث نظام أسماء النطاقات التي تنفِّذها. وتنفِّذ Intra هذه الطلبات عبر بروتوكول HTTPS لتشفيرها.</string>
+  <string name="default_transport_label">بروتوكول النقل التلقائي</string>
+  <string name="insecure_transport">غير مُشفَّر</string>
+  <string name="insecure_transport_headline">نظام أسماء النطاقات الأساسي غير مُشفَّر</string>
+  <string name="insecure_transport_body">تستخدم معظم الأجهزة والشبكات نظام أسماء نطاقات أساسي، ويكون غير مُشفَّر لذلك يمكن لأي مستخدم على الشبكة مراقبة طلبات بحث نظام أسماء النطاقات أو تعديلها. تسمح بعض الأجهزة الجديدة بانتقال نظام أسماء النطاقات عبر طبقة النقل الآمنة التي تشفِّر طلبات بحثك ولكن لا يمكنها حمايتك إذا كان الخادِم ضارًا.</string>
   <string name="server_label">خادم نظام أسماء النطاقات الآمن</string>
-  <string name="insecure_server_label">خادم نظام أسماء النطاقات الوارد من الشبكة</string>
+  <string name="server_headline">موثوق به</string>
+  <string name="server_body">يعرض هذا الحقل اسم الخادِم الآمن لنظام أسماء النطاقات الذي تستخدمه. يمكنك أيضًا التغيير إلى خادِم مختلف في قائمة \"الإعدادات\".</string>
+  <string name="default_server_label">خادم نظام أسماء النطاقات الحالي</string>
+  <string name="insecure_server_headline">يمكنك اختيار خادم نظام أسماء النطاقات الذي تريد استخدامه</string>
+  <string name="insecure_server_body">عند إيقاف Intra، يتم إجراء ضبط مسبق لمعظم الأجهزة لكي تستخدم خادم نظام أسماء النطاقات الذي اختاره
+    مشغِّل الشبكة. يعرض هذا الحقل عنوان IP لخادم نظام أسماء النطاقات الذي يستخدمه جهازك
+    حاليًا. باستخدام Intra أو Android P، يمكنك بسهولة اختيار الخادم الذي تريده.</string>
+  <string name="strict_mode_server_headline">لقد اخترت خادمًا آمنًا</string>
+  <string name="strict_mode_server_body">يعرض هذا الحقل اسم خادم نظام أسماء النطاقات الذي ضبطته في إعداد نظام أسماء النطاقات الخاص على نظام
+    التشغيل Android.  عند إيقاف أداة Intra، سترسل تطبيقاتك طلبات بحث نظام أسماء النطاقات إلى هذا الخادم.</string>
   <string name="unknown_server">(خادم غير معروف)</string>
   <string name="show_history">إظهار الطلبات الحديثة</string>
   <string name="query_label">الطلب</string>
@@ -73,12 +79,6 @@
     غير متوافق مع Intra، يمكنك إضافته هنا.</string>
   <string name="excluded_apps_title">تمييز التطبيقات المطلوب استبعادها من Intra</string>
   <string name="old_android">هذه الوظيفة غير متوفّرة على إصدار نظام تشغيل Android عندك.</string>
-  <string name="before_feedback">ساعدنا على تحسين Intra! ما زال Intra منتجًا في طور النشوء ونحن بحاجة لمساعدتك لتحسينه.
-    يُرجى إعلامنا بميزاته التي تعمل بشكلٍ جيد وما به من أعطال. شكرًا لك!</string>
-  <string name="feedback_hint">ملاحظاتك</string>
-  <string name="after_feedback">سيتم إرسال هذه المعلومات إلى فريق عمل Intra. يُرجى عدم إضافة أي بيانات شخصية
-    إلى ملاحظاتك.</string>
-  <string name="submit_feedback">إرسال</string>
   <string name="notification_title">إعداد حماية نظام أسماء النطاقات نشط</string>
   <string name="notification_content">انقر لتغيير إعداد حماية نظام أسماء النطاقات</string>
   <string name="channel_name">إشعار الحماية النشطة لنظام أسماء النطاقات</string>

--- a/Android/app/src/main/res/values-b+es+419/strings.xml
+++ b/Android/app/src/main/res/values-b+es+419/strings.xml
@@ -1,27 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Un camino más seguro hacia una Internet más abierta</string>
-  <string name="intro_benefit_body">Cuando usas Internet, tus dispositivos tienen que buscar direcciones en una lista de contactos en línea. A veces, tu conexión puede proporcionarte una dirección incorrecta.</string>
-  <string name="intro_manipulation_headline">Protección contra direcciones incorrectas</string>
-  <string name="intro_manipulation_body">Intra encripta tu conexión de DNS para impedir que recibas direcciones incorrectas que te dirijan a callejones sin salida (manipulación de DNS).</string>
-  <string name="intro_details_headline">Intra necesita supervisar el tráfico de red para habilitar la protección.</string>
-  <string name="intro_details_body">Cuando veas la solicitud de conexión, presiona Aceptar para comenzar. De forma predeterminada, tus consultas se dirigirán al DNS público de Google (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidad</a>). Puedes elegir otro servicio en la configuración de la app.</string>
+  <string name="intro_benefit_headline">Un acceso a Internet más abierto</string>
+  <string name="intro_benefit_body">Intra te protege de la manipulación de DNS, un ataque cibernético que se utiliza para bloquear el acceso a sitios de noticias, plataformas de medios sociales y apps de mensajería.\n\nSi bien Intra te protege de la manipulación de DNS, existen otros ataques y técnicas de bloqueo más complicados contra los cuales Intra no ofrece protección.</string>
+  <string name="intro_manipulation_headline">Protección contra la manipulación de DNS</string>
+  <string name="intro_manipulation_body">Intra protege tu conexión al sistema de nombres de dominio (DNS), el cual te brinda las direcciones exactas que necesitas para visitar un sitio web o abrir una app.\n\nIntra utiliza la encriptación para garantizar que los resultados no se puedan manipular, lo que te ayuda a acceder a Internet de manera segura.</string>
+  <string name="intro_details_headline">Una última cosa…</string>
+  <string name="intro_details_body">Presiona Aceptar para permitir que Intra proteja tus solicitudes de DNS. De forma predeterminada, se dirigirán al DNS público de Google (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidad</a>). Puedes elegir otro servicio en la configuración de la app.</string>
   <string name="intro_back">anterior</string>
   <string name="intro_next">siguiente</string>
   <string name="intro_accept">aceptar</string>
-  <string name="about_headline">DNS confiable y seguro</string>
-  <string name="about_text">Intra protege tus búsquedas de DNS, ya que las enruta en una conexión HTTPS segura. Este proceso reduce las probabilidades de que se te envíe al sitio equivocado o de que alguien observe o bloquee tu navegación.</string>
-  <string name="privacy_text">De forma predeterminada, tus consultas se enrutarán al <a href="https://developers.google.com/speed/public-dns/">DNS público de Google</a> (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidad</a>). También puedes optar por usar <a href="https://cloudflare-dns.com">Cloudflare</a> (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Política de Privacidad</a>) o cualquier otro servicio de DNS por HTTPS.</string>
-  <string name="accept">Comenzar</string>
   <string name="drawer_open">Abre el panel lateral de navegación</string>
   <string name="drawer_close">Cierra el panel lateral de navegación</string>
   <string name="home">Página principal</string>
   <string name="settings">Configuración</string>
-  <string name="feedback">Enviar comentarios</string>
   <string name="support">Asistencia</string>
-  <string name="privacy_link">Política de privacidad</string>
+  <string name="privacy_link">Política de Privacidad</string>
   <string name="tos_link">Condiciones del servicio</string>
   <string name="source_code">Código fuente</string>
-  <string name="short_credits_text">Intra es un proyecto experimental de código abierto de <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra es una creación de <a href="https://jigsaw.google.com">Jigsaw</a>. Las ubicaciones de IP están basadas en datos de DB-IP.com.</string>
   <string name="indicator_on">Activado</string>
   <string name="indicator_off">Desactivado</string>
@@ -41,11 +35,26 @@
   <string name="explanation_failing">Advertencia: Están fallando las consultas. Es posible que te convenga elegir otro servidor y reiniciar Intra.</string>
   <string name="system_details">Detalles del sistema</string>
   <string name="num_requests">Búsquedas totales</string>
+  <string name="num_requests_headline">Las consultas de DNS tienen lugar cuando tu dispositivo busca la dirección IP de un nombre de dominio</string>
+  <string name="num_requests_body">Este valor muestra la cantidad total de consultas de DNS que realizó tu dispositivo mientras Intra estaba activo. Intra encripta estas consultas y las envía a un servidor de confianza para garantizar que obtengas resultados auténticos.</string>
   <string name="queries_per_minute">Búsquedas recientes</string>
+  <string name="queries_per_minute_headline">Las consultas de DNS tienen lugar al inicio de cada conexión</string>
+  <string name="queries_per_minute_body">Este valor muestra la cantidad de consultas de DNS que realizó tu dispositivo durante el último minuto. Para cargar una página web compleja, pueden requerirse más de cien consultas de DNS.</string>
   <string name="transport_label">Transporte encriptado</string>
-  <string name="insecure_transport_label">Transporte sin encriptar</string>
+  <string name="transport_headline">La encriptación protege tus consultas de los intrusos</string>
+  <string name="transport_body">Cuando utilizas Intra, se encriptan tus consultas de DNS, de manera que solo tú y tu servidor DNS pueden ver las consultas que realizas. Para la encriptación, Intra implementa el protocolo de DNS por HTTPS.</string>
+  <string name="default_transport_label">Transporte predeterminado</string>
+  <string name="insecure_transport">sin encriptar</string>
+  <string name="insecure_transport_headline">El DNS básico no está encriptado</string>
+  <string name="insecure_transport_body">La mayoría de los dispositivos y las redes utilizan un DNS básico, que no está encriptado, por lo que cualquier usuario de la red podría observar o modificar tus consultas de DNS. Algunos dispositivos nuevos admiten DNS por TLS, que encripta tus consultas, pero no puede protegerte si el servidor es malicioso.</string>
   <string name="server_label">Servidor DNS seguro</string>
-  <string name="insecure_server_label">Servidor DNS proporcionado por la red</string>
+  <string name="server_headline">Te mereces usar un servidor DNS de confianza</string>
+  <string name="server_body">Este campo muestra el nombre del servidor DNS seguro que utilizas. También puedes cambiar de servidor en el menú de configuración.</string>
+  <string name="default_server_label">Servidor DNS actual</string>
+  <string name="insecure_server_headline">Puedes elegir tu propio servidor DNS</string>
+  <string name="insecure_server_body">Si se inhabilita Intra, la mayoría de los dispositivos están preconfigurados para usar el servidor DNS que elija tu operador de red. Este campo muestra la dirección IP del servidor DNS que tu dispositivo está utilizando actualmente. Con Intra o Android P, puedes seleccionar fácilmente el servidor que desees.</string>
+  <string name="strict_mode_server_headline">Seleccionaste un servidor seguro</string>
+  <string name="strict_mode_server_body">Este campo muestra el nombre del servidor DNS que configuraste en el parámetro de configuración DNS privado de Android.  Si se inhabilita Intra, tus apps deben enviar las consultas de DNS a este servidor.</string>
   <string name="unknown_server">(servidor desconocido)</string>
   <string name="show_history">Mostrar búsquedas recientes</string>
   <string name="query_label">Búsqueda</string>
@@ -61,10 +70,6 @@
   <string name="excluded_apps_summary">Las consultas de DNS de las apps seleccionadas no pasarán por Intra. Si una app parece ser incompatible con Intra, puedes agregarla aquí.</string>
   <string name="excluded_apps_title">Marca las apps que desees excluir de Intra</string>
   <string name="old_android">Esta función no está disponible en tu versión de Android.</string>
-  <string name="before_feedback">Ayúdanos a mejorar Intra. Estas son las primeras etapas del producto y necesitamos tu ayuda para mejorarlo. Cuéntanos qué funciona y qué no. Gracias.</string>
-  <string name="feedback_hint">Tus comentarios</string>
-  <string name="after_feedback">Esta información se enviará al equipo de Intra. No incluyas información personal en tus comentarios.</string>
-  <string name="submit_feedback">Enviar</string>
   <string name="notification_title">La protección de DNS está activa</string>
   <string name="notification_content">Presiona para cambiar el parámetro de configuración de la protección de DNS</string>
   <string name="channel_name">Notificación sobre la activación de la protección de DNS</string>

--- a/Android/app/src/main/res/values-de/strings.xml
+++ b/Android/app/src/main/res/values-de/strings.xml
@@ -1,10 +1,10 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Sicherer zu einem offeneren Internet</string>
-  <string name="intro_benefit_body">Wenn Sie auf einem Gerät eine Internetadresse eingeben, wird sie in einer Liste nachgeschlagen. Manchmal wird dann jedoch eine falsche Adresse aufgerufen.</string>
-  <string name="intro_manipulation_headline">Schutz vor manipulierten Adressen</string>
-  <string name="intro_manipulation_body">Mit Intra wird Ihre DNS-Verbindung verschlüsselt. Dadurch sind Sie vor Verbindungen mit Adressen geschützt, für die DNS-Manipulationen vorliegen.</string>
-  <string name="intro_details_headline">Für den Schutz durch Intra muss der Netzwerkverkehr überwacht werden</string>
-  <string name="intro_details_body">Wenn die Verbindungsanfrage angezeigt wird, tippe auf OK. Standardmäßig werden deine Abfragen an Google Public DNS weitergeleitet (<a href="https://developers.google.com/speed/public-dns/privacy">Datenschutzerklärung</a>). Du kannst in den App-Einstellungen aber auch einen anderen Dienst auswählen.</string>
+  <string name="intro_benefit_headline">Mehr Sicherheit für ein offeneres Internet</string>
+  <string name="intro_benefit_body">Mit Intra sind Sie vor DNS-Manipulationen geschützt. Das sind Cyberangriffe, bei denen Ihr Zugriff auf Nachrichtenwebsites, soziale Medien und Messaging-Apps blockiert wird.\n\nEs gibt allerdings noch weitere und komplexere Techniken und Angriffe, gegen die Intra keinen Schutz bietet.</string>
+  <string name="intro_manipulation_headline">Schutz vor DNS-Manipulation</string>
+  <string name="intro_manipulation_body">Mit Intra wird die Verbindung zum Domain Name System (DNS) geschützt. Dieses System liefert die genauen Adressen zum Öffnen einer Website oder einer App.\n\nDurch Verschlüsselung wird sichergestellt, dass die Adressen nicht manipuliert werden können – für einen sicheren Internetzugriff.</string>
+  <string name="intro_details_headline">Last but not least…</string>
+  <string name="intro_details_body">Tippen Sie auf OK, um DNS-Abfragen mit Intra zu schützen. Standardmäßig werden sie dann an Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Datenschutzerklärung</a>) weitergeleitet. In den App-Einstellungen können Sie aber auch einen anderen Dienst auswählen.</string>
   <string name="intro_back">Zurück</string>
   <string name="intro_next">Weiter</string>
   <string name="intro_accept">Zustimmen</string>
@@ -26,7 +26,7 @@
   <string name="status_upgraded">Geringer Schutz</string>
   <string name="explanation_upgraded">Ihre Verbindung wird aktuell durch die Android-Einstellung \"Privates DNS\" geschützt. Dieser Schutz kann jedoch durch Angreifer deaktiviert oder umgangen werden.</string>
   <string name="status_strict">Geschützt durch Android</string>
-  <string name="explanation_strict">In Intra wurde erkannt, dass die Android-Einstellung \"Privates DNS\" aktiviert ist. Ihre DNS-Abfragen sind also schon geschützt, d. h., Sie benötigen Intra eigentlich nicht.</string>
+  <string name="explanation_strict">Auf  Ihrem Gerät ist die Android-Einstellung \"Privates DNS\" aktiviert. Deshalb sind Ihre DNS-Abfragen bereits geschützt. Sie müssen Intra nicht aktivieren.</string>
   <string name="status_starting">Wird gestartet…</string>
   <string name="explanation_starting">Bitte warten Sie. Die Serververbindung wird aufgebaut.</string>
   <string name="status_waiting">Bitte warten…</string>
@@ -35,11 +35,26 @@
   <string name="explanation_failing">Warnung: Ihre Abfragen schlagen fehl. Bitte wählen Sie einen anderen Server aus und starten Sie Intra neu.</string>
   <string name="system_details">Systemdetails</string>
   <string name="num_requests">Abfragen seit Installation</string>
+  <string name="num_requests_headline">Mit DNS-Abfragen ruft Ihr Gerät die IP-Adresse für einen Domainnamen ab</string>
+  <string name="num_requests_body">Dieser Wert entspricht der Gesamtzahl der DNS-Abfragen, die von Ihrem Gerät gesendet wurden, während Intra aktiv war. Die Anfragen werden von Intra verschlüsselt und an einen vertrauenswürdigen Server gesendet, sodass die Ergebnisse nicht manipuliert werden können.</string>
   <string name="queries_per_minute">Letzte Abfragen</string>
+  <string name="queries_per_minute_headline">DNS-Abfragen erfolgen zu Beginn einer Verbindung</string>
+  <string name="queries_per_minute_body">Dieser Wert entspricht der Gesamtzahl der DNS-Abfragen, die von Ihrem Gerät in der letzten Minute gesendet wurden. Um eine komplexe Webseite zu laden, können über hundert DNS-Abfragen nötig sein.</string>
   <string name="transport_label">Verschlüsselter Transport</string>
-  <string name="insecure_transport_label">Unverschlüsselter Transport</string>
+  <string name="transport_headline">Abfragen werden durch Verschlüsselung geschützt</string>
+  <string name="transport_body">Mit Intra werden Ihre DNS-Abfragen verschlüsselt, sodass sie nur für Ihren DNS-Server lesbar sind. Die Verschlüsselung erfolgt über HTTPS.</string>
+  <string name="default_transport_label">Standardübertragung</string>
+  <string name="insecure_transport">unverschlüsselt</string>
+  <string name="insecure_transport_headline">Standardmäßig werden DNS-Verbindungen nicht verschlüsselt</string>
+  <string name="insecure_transport_body">Die meisten Geräte und Netzwerke nutzen standardmäßige DNS-Verbindungen, die nicht verschlüsselt werden. So kann jeder im Netzwerk die DNS-Abfragen abfangen und manipulieren. Einige neue Geräte unterstützen DNS über TLS. Damit werden zwar die Abfragen verschlüsselt, es bietet aber keinen Schutz, wenn der Server manipuliert wurde.</string>
   <string name="server_label">Sicherer DNS-Server</string>
-  <string name="insecure_server_label">Vom Netzwerk bereitgestellter DNS-Server</string>
+  <string name="server_headline">Ein vertrauenswürdiger DNS-Server</string>
+  <string name="server_body">Dieses Feld enthält den Namen des sicheren DNS-Servers, den Sie verwenden. Sie können aber auch im Menü \"Einstellungen\" einen anderen Server auswählen.</string>
+  <string name="default_server_label">Aktueller DNS-Server</string>
+  <string name="insecure_server_headline">DNS-Server selbst auswählen</string>
+  <string name="insecure_server_body">Die meisten Geräte sind so konfiguriert, dass bei deaktivierter Intra App die von Ihrem Netzwerkbetreiber ausgewählten DNS-Server genutzt werden. In diesem Feld wird die IP-Adresse des DNS-Servers angezeigt, den Ihr Gerät gerade verwendet. Mit Android P oder der Intra App können Sie selbst einen Server auswählen.</string>
+  <string name="strict_mode_server_headline">Sicherer Server ausgewählt</string>
+  <string name="strict_mode_server_body">In diesem Feld wird der Name des DNS-Servers angezeigt, den Sie in der Android-Einstellung \"Privates DNS\" konfiguriert haben.  Ist Intra deaktiviert, sollten DNS-Abfragen Ihrer Apps an diesen Server gesendet werden.</string>
   <string name="unknown_server">(unbekannter Server)</string>
   <string name="show_history">Letzte Abfragen anzeigen</string>
   <string name="query_label">Abfrage</string>

--- a/Android/app/src/main/res/values-en-rGB/strings.xml
+++ b/Android/app/src/main/res/values-en-rGB/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">A safer route to a more open Internet</string>
-  <string name="intro_benefit_body">When you use the Internet, your device needs to look up addresses in an Internet contact list. Sometimes your connection can give you the wrong address.</string>
-  <string name="intro_manipulation_headline">Protection from wrong addresses</string>
-  <string name="intro_manipulation_body">Intra protects you from getting bad addresses that lead to dead ends (DNS manipulation) by encrypting your DNS connection.</string>
-  <string name="intro_details_headline">Intra needs to monitor network traffic to enable protection</string>
-  <string name="intro_details_body">Tap OK when you see the connection request to start. By default, your queries will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.</string>
+  <string name="intro_benefit_headline">More open Internet access</string>
+  <string name="intro_benefit_body">Intra protects you from DNS manipulation, a cyber attack used to block access to news sites, social media platforms and messaging apps.\n\nWhile Intra protects you against DNS manipulation, there are other more complicated blocking techniques and attacks that Intra doesn\'t protect against.</string>
+  <string name="intro_manipulation_headline">Protection from DNS manipulation</string>
+  <string name="intro_manipulation_body">Intra protects your connection to the Domain Name System (DNS), which provides the exact addresses that you need to visit a website or open an app.\n\nIntra uses encryption to ensure that results can\’t be manipulated, helping you safely access the Internet.</string>
+  <string name="intro_details_headline">One last thing…</string>
+  <string name="intro_details_body">Tap OK to allow Intra to protect your DNS requests. By default, they will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.</string>
   <string name="intro_back">back</string>
   <string name="intro_next">next</string>
   <string name="intro_accept">accept</string>
-  <string name="about_headline">Honest and secure DNS</string>
-  <string name="about_text">Intra protects your DNS queries by routing them over a secure HTTPS connection. This reduces the
-    chance that you will be sent to the wrong site, or have your browsing blocked or observed.</string>
-  <string name="privacy_text">By default, your queries will be routed to
-    <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>).
-    You can also choose to use <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Privacy Policy</a>)
-    or any other DNS-over-HTTPS service.</string>
-  <string name="accept">Get Started</string>
   <string name="drawer_open">Open navigation drawer</string>
   <string name="drawer_close">Close navigation drawer</string>
   <string name="home">Home</string>
   <string name="settings">Settings</string>
-  <string name="feedback">Submit Feedback</string>
   <string name="support">Support</string>
   <string name="privacy_link">Privacy Policy</string>
   <string name="tos_link">Terms of Service</string>
   <string name="source_code">Source Code</string>
-  <string name="short_credits_text">Intra is an experimental open-source project by <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra was made by <a href="https://jigsaw.google.com">Jigsaw</a>. IP locations are based on data
     from DB-IP.com.</string>
   <string name="indicator_on">On</string>
@@ -51,11 +39,36 @@
   <string name="explanation_failing">Warning: Queries are failing. You may want to choose a different server and restart Intra.</string>
   <string name="system_details">System details</string>
   <string name="num_requests">Lifetime queries</string>
+  <string name="num_requests_headline">DNS queries happen when your device looks up the IP address for a domain name</string>
+  <string name="num_requests_body">This value shows the total number of DNS queries that your device has performed while Intra was
+    active. Intra encrypts these queries and sends them to a trusted server to make sure that you\'re
+    receiving authentic results.</string>
   <string name="queries_per_minute">Recent queries</string>
+  <string name="queries_per_minute_headline">DNS queries happen at the beginning of each connection</string>
+  <string name="queries_per_minute_body">This value shows the number of DNS queries that your device has performed in the last minute.
+    Loading a complex web page can require over a hundred DNS queries.</string>
   <string name="transport_label">Encrypted transport</string>
-  <string name="insecure_transport_label">Unencrypted transport</string>
+  <string name="transport_headline">Encryption protects your queries from prying eyes</string>
+  <string name="transport_body">When you use Intra, your DNS queries are encrypted, so that only you and your DNS server can see
+    what DNS queries you are making. Intra implements the DNS over HTTPS protocol for encryption.</string>
+  <string name="default_transport_label">Default transport</string>
+  <string name="insecure_transport">unencrypted</string>
+  <string name="insecure_transport_headline">Basic DNS is unencrypted</string>
+  <string name="insecure_transport_body">Most devices and networks use basic DNS, which is unencrypted, so your DNS queries could be
+    observed or modified by anyone on the network. Some new devices support DNS over TLS, which
+    encrypts your queries but can\'t protect you if the server is malicious.</string>
   <string name="server_label">Secure DNS server</string>
-  <string name="insecure_server_label">Network-provided DNS server</string>
+  <string name="server_headline">You deserve to use a trustworthy DNS server</string>
+  <string name="server_body">This field shows the name of the secure DNS server that you\'re using. You can also change to a
+    different server in the Settings menu.</string>
+  <string name="default_server_label">Current DNS server</string>
+  <string name="insecure_server_headline">You can choose your own DNS server</string>
+  <string name="insecure_server_body">When Intra is disabled, most devices are pre-configured to use the DNS server that your network
+    operator picks. This field shows the IP address of the DNS server that your device is currently
+    using. With Intra or Android P, you can easily select a server of your choice.</string>
+  <string name="strict_mode_server_headline">You\'ve selected a secure server</string>
+  <string name="strict_mode_server_body">This field shows the name of the DNS server that you configured in Android\'s Private DNS
+    setting.  When Intra is disabled, your apps should send DNS queries to this server.</string>
   <string name="unknown_server">(unknown server)</string>
   <string name="show_history">Show recent queries</string>
   <string name="query_label">Query</string>
@@ -72,12 +85,6 @@
     incompatible with Intra, you can add it here.</string>
   <string name="excluded_apps_title">Mark apps to exclude from Intra</string>
   <string name="old_android">This functionality is not available on your version of Android.</string>
-  <string name="before_feedback">Help us to improve Intra! Intra is an early-stage product and we need your help to make it better.
-    Tell us what\'s working, and what\'s not. Thanks!</string>
-  <string name="feedback_hint">Your feedback</string>
-  <string name="after_feedback">This information will be sent to the Intra team. Please do not include any personal information
-    in your feedback.</string>
-  <string name="submit_feedback">Submit</string>
   <string name="notification_title">DNS protection is active</string>
   <string name="notification_content">Tap to change DNS protection setting</string>
   <string name="channel_name">DNS Protection Active Notification</string>

--- a/Android/app/src/main/res/values-es/strings.xml
+++ b/Android/app/src/main/res/values-es/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Una ruta más segura a un Internet más abierto</string>
-  <string name="intro_benefit_body">Cuando utilizas Internet, tu dispositivo busca direcciones en una lista de contactos de Internet. A veces, puede ocurrir que tu conexión te ofrezca una dirección incorrecta.</string>
-  <string name="intro_manipulation_headline">Protección contra direcciones incorrectas</string>
-  <string name="intro_manipulation_body">Intra te ayuda a evitar direcciones incorrectas que dirigen a páginas no deseadas (manipulación de DNS) cifrando tu conexión DNS.</string>
-  <string name="intro_details_headline">Para ofrecer protección, Intra necesita supervisar el tráfico de red</string>
-  <string name="intro_details_body">Para empezar, toca OK cuando veas la solicitud de conexión. De forma predeterminada, tus consultas se dirigirán a Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">política de privacidad</a>). Puedes elegir otro servicio en los ajustes de la aplicación.</string>
+  <string name="intro_benefit_headline">Más acceso abierto a Internet</string>
+  <string name="intro_benefit_body">Intra te protege frente a la manipulación de DNS, un ciberataque que se utiliza para bloquear el acceso a sitios web de noticias, plataformas de redes sociales y aplicaciones de mensajería.\n\nAunque Intra te protege frente a este tipo de manipulación, hay otros ataques y técnicas de bloqueo más complicados para los que Intra no ofrece protección.</string>
+  <string name="intro_manipulation_headline">Protección frente a manipulación de DNS</string>
+  <string name="intro_manipulation_body">Intra protege tu conexión al sistema de nombres de dominio (DNS), que proporciona las direcciones exactas que necesitas para visitar un sitio web o abrir una aplicación.\n\nIntra cifra los resultados para asegurarse de que no se puedan manipular, lo que te ayuda a acceder de forma segura a Internet.</string>
+  <string name="intro_details_headline">Una última cosa…</string>
+  <string name="intro_details_body">Toca Aceptar para permitir que Intra proteja tus solicitudes de DNS. De manera predeterminada, estas se enrutarán a Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">política de privacidad</a>). Puedes elegir otro servicio en la aplicación Ajustes.</string>
   <string name="intro_back">atrás</string>
   <string name="intro_next">siguiente</string>
   <string name="intro_accept">aceptar</string>
-  <string name="about_headline">DNS seguro y honesto</string>
-  <string name="about_text">Intra protege tus consultas de DNS enviándolas a través de una conexión segura de HTTPS.
-        Esto reduce la posibilidad de que se te redirija al sitio equivocado o que tu navegación sea bloqueada o monitorizada.</string>
-  <string name="privacy_text">De manera predeterminada, tus consultas se enviarán a
-    <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">política de privacidad</a>).
-    También puedes usar <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">política de privacidad</a>)
-    o cualquier otro servicio de DNS sobre HTTPS.</string>
-  <string name="accept">Comenzar</string>
   <string name="drawer_open">Abre el panel de navegación</string>
   <string name="drawer_close">Cierra el panel de navegación</string>
   <string name="home">Inicio</string>
   <string name="settings">Ajustes</string>
-  <string name="feedback">Enviar comentarios</string>
   <string name="support">Asistencia</string>
   <string name="privacy_link">Política de privacidad</string>
   <string name="tos_link">Condiciones de uso</string>
   <string name="source_code">Código fuente</string>
-  <string name="short_credits_text">Intra es un proyecto experimental de código abierto desarrollado por <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra ha sido desarrollado por
             <a href="https://jigsaw.google.com">Jigsaw</a> con la ayuda de Google.
             Las ubicaciones de las direcciones IP están basadas en información de DB-IP.com.</string>
@@ -50,11 +38,26 @@
   <string name="explanation_failing">Advertencia: No se están procesando las consultas. Te aconsejamos que elijas otro servidor y reinicies Intra.</string>
   <string name="system_details">Detalles del sistema</string>
   <string name="num_requests">Consultas totales</string>
+  <string name="num_requests_headline">Las consultas de DNS se generan cuando tu dispositivo busca la dirección IP de un nombre de dominio</string>
+  <string name="num_requests_body">Este valor muestra el número total de consultas de DNS que tu dispositivo ha realizado mientras Intra estaba activo. Intra cifra estas consultas y las envía a un servidor de confianza para asegurarse de que obtengas resultados auténticos.</string>
   <string name="queries_per_minute">Consultas recientes</string>
+  <string name="queries_per_minute_headline">Las consultas de DNS se generan al principio de cada conexión</string>
+  <string name="queries_per_minute_body">Este valor muestra el número de consultas de DNS que tu dispositivo ha realizado en el último minuto. Para cargar una página web compleja, es posible que se necesiten más de cien consultas de DNS.</string>
   <string name="transport_label">Transporte encriptado</string>
-  <string name="insecure_transport_label">Transporte no encriptado</string>
+  <string name="transport_headline">El cifrado protege tus consultas frente a las miradas indiscretas</string>
+  <string name="transport_body">Cuando un usuario utiliza Intra, sus consultas de DNS se cifran para que solo él y su servidor DNS puedan ver qué consultas de DNS está haciendo. Intra implementa el DNS a través del protocolo HTTPS para el cifrado.</string>
+  <string name="default_transport_label">Transporte predeterminado</string>
+  <string name="insecure_transport">sin cifrar</string>
+  <string name="insecure_transport_headline">El DNS básico no está cifrado</string>
+  <string name="insecure_transport_body">La mayoría de los dispositivos y las redes utilizan un DNS básico (sin cifrar), por lo que cualquier usuario de la red podría ver o modificar tus consultas de DNS. Algunos dispositivos nuevos admiten DNS a través de TLS, lo cual permite cifrar las consultas, pero no te protege frente a un servidor malicioso.</string>
   <string name="server_label">Servidor DNS seguro</string>
-  <string name="insecure_server_label">Servidor DNS de la red</string>
+  <string name="server_headline">Te mereces usar un servidor DNS de confianza</string>
+  <string name="server_body">Este campo muestra el nombre del servidor DNS seguro que estás usando. Si quieres, puedes cambiar de servidor en el menú Ajustes.</string>
+  <string name="default_server_label">Servidor DNS actual</string>
+  <string name="insecure_server_headline">Puedes seleccionar tu propio servidor DNS</string>
+  <string name="insecure_server_body">Cuando Intra está inhabilitada, la mayoría de los dispositivos utilizarán el servidor DNS que haya elegido tu operador de red, ya que están configurados así de manera predeterminada. En este campo se muestra la dirección IP del servidor DNS que está utilizando tu dispositivo. Con Intra o Android P, puedes seleccionar el servidor que quieras fácilmente.</string>
+  <string name="strict_mode_server_headline">Has seleccionado un servidor seguro</string>
+  <string name="strict_mode_server_body">En este campo se muestra el nombre del servidor DNS que has configurado en el ajuste DNS privado de Android.  Cuando Intra está inhabilitada, las aplicaciones deberían enviar las consultas de DNS a este servidor.</string>
   <string name="unknown_server">(servidor desconocido)</string>
   <string name="show_history">Mostrar consultas recientes</string>
   <string name="query_label">Consulta</string>
@@ -70,12 +73,6 @@
   <string name="excluded_apps_summary">Las consultas de DNS de las aplicaciones seleccionadas no se enviarán a través de Intra. Si una aplicación parece ser incompatible con Intra, puedes añadirla aquí.</string>
   <string name="excluded_apps_title">Marcar aplicaciones que excluir de Intra</string>
   <string name="old_android">Esta función no está disponible en tu versión de Android.</string>
-  <string name="before_feedback">¡Ayúdanos a mejorar Intra!
-        Intra es un producto en desarrollo y necesitamos tu ayuda para mejorarlo.
-        Cuéntanos qué está funcionando y qué no. ¡Gracias!</string>
-  <string name="feedback_hint">Tus comentarios</string>
-  <string name="after_feedback">Esta información se enviará al equipo de Intra. No incluyas ninguna información personal.</string>
-  <string name="submit_feedback">Enviar</string>
   <string name="notification_title">Protección de DNS activada</string>
   <string name="notification_content">Toca para cambiar la configuración de tu protección de DNS</string>
   <string name="channel_name">Notificación de protección de DNS activada</string>

--- a/Android/app/src/main/res/values-fr/strings.xml
+++ b/Android/app/src/main/res/values-fr/strings.xml
@@ -1,39 +1,27 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Une méthode d\'accès plus sûre à un Internet plus ouvert</string>
-  <string name="intro_benefit_body">Lorsque votre appareil se connecte à Internet, il doit rechercher des adresses dans une liste de contacts Internet. Or, il arrive que l\'adresse ainsi récupérée soit incorrecte.</string>
-  <string name="intro_manipulation_headline">Protection contre les adresses incorrectes</string>
-  <string name="intro_manipulation_body">Intra vous empêche de récupérer des adresses incorrectes menant à une impasse (manipulation DNS) en chiffrant votre connexion DNS.</string>
-  <string name="intro_details_headline">Pour activer la protection, Intra doit surveiller le trafic réseau</string>
-  <string name="intro_details_body">Pour démarrer, appuyez sur \"OK\" lorsque la demande de connexion s\'affiche. Par défaut, vos requêtes sont routées vers le DNS public de Google (<a href="https://developers.google.com/speed/public-dns/privacy">Règles de confidentialité</a>). Vous pouvez choisir un autre service dans les paramètres de l\'application.</string>
+  <string name="intro_benefit_headline">Un accès Internet plus ouvert</string>
+  <string name="intro_benefit_body">Intra vous protège contre la manipulation DNS, une technique de piratage visant à bloquer l\'accès aux sites de presse, aux plates-formes de médias sociaux et aux applications de messagerie.\n\nIl existe cependant des types d\'attaques et de techniques de blocage plus complexes que la manipulation DNS, contre lesquels Intra ne vous protège pas.</string>
+  <string name="intro_manipulation_headline">Protection contre la manipulation DNS</string>
+  <string name="intro_manipulation_body">Intra protège la connexion au système de noms de domaine (DNS) qui fournit les adresses exactes dont vous avez besoin pour consulter un site Internet ou pour ouvrir une application.\n\nIntra recourt au chiffrement pour empêcher toute manipulation des résultats, et pour sécuriser votre accès à Internet.</string>
+  <string name="intro_details_headline">Une dernière chose…</string>
+  <string name="intro_details_body">Appuyez sur \"OK\" pour permettre à Intra de protéger vos requêtes DNS. Celles-ci seront routées par défaut vers le DNS public de Google (<a href="https://developers.google.com/speed/public-dns/privacy">Règles de confidentialité</a>). Vous pouvez choisir un autre service dans les paramètres de l\'application.</string>
   <string name="intro_back">précédent</string>
   <string name="intro_next">suivant</string>
   <string name="intro_accept">accepter</string>
-  <string name="about_headline">Un DNS sans censure et sécurisé</string>
-  <string name="about_text">Intra protège vos requêtes DNS en les routant via une connexion HTTPS sécurisée. Les risques
-    que vous soyez redirigé vers le mauvais site ou que votre navigation soit bloquée ou épiée sont ainsi réduits.</string>
-  <string name="privacy_text">Par défaut, vos requêtes seront transmises au
-    <a href="https://developers.google.com/speed/public-dns/">DNS public Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Règles de confidentialité</a>).
-    Vous pouvez également choisir d\'utiliser <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Règles de confidentialité</a>)
-    ou tout autre service DNS over HTTPS (DoH).</string>
-  <string name="accept">Commencer</string>
   <string name="drawer_open">Ouvrir le panneau de navigation</string>
   <string name="drawer_close">Fermer le panneau de navigation</string>
   <string name="home">Accueil</string>
   <string name="settings">Paramètres</string>
-  <string name="feedback">Envoyer des commentaires</string>
   <string name="support">Assistance</string>
   <string name="privacy_link">Règles de confidentialité</string>
   <string name="tos_link">Conditions d\'utilisation</string>
   <string name="source_code">Code source</string>
-  <string name="short_credits_text">Intra est un projet Open Source expérimental développé par <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra est développé par <a href="https://jigsaw.google.com">Jigsaw</a>. Les emplacements IP sont basés sur les données
     issues de DB-IP.com.</string>
   <string name="indicator_on">Activé</string>
   <string name="indicator_off">Désactivé</string>
   <string name="status_exposed">Exposées</string>
-  <string name="explanation_exposed">Votre connexion est vulnérable aux attaques DNS.</string>
+  <string name="explanation_exposed">Votre connexion est exposée aux attaques DNS.</string>
   <string name="status_protected">Protégées</string>
   <string name="explanation_protected">Votre connexion est protégée contre les attaques DNS.</string>
   <string name="status_upgraded">Vulnérables</string>
@@ -51,11 +39,33 @@
   <string name="explanation_failing">Avertissement : Échec des requêtes. Vous pouvez choisir un autre serveur et redémarrer Intra.</string>
   <string name="system_details">Détails du système</string>
   <string name="num_requests">Requêtes protégées jusqu\'à maintenant</string>
+  <string name="num_requests_headline">Des requêtes DNS sont envoyées lorsqu\'un appareil recherche l\'adresse IP d\'un nom de domaine</string>
+  <string name="num_requests_body">Cette valeur indique le nombre total de requêtes DNS envoyées par votre appareil alors qu\'Intra était
+    actif. Intra chiffre ces requêtes et les envoie vers un serveur de confiance afin de vous
+    garantir des résultats authentiques.</string>
   <string name="queries_per_minute">Requêtes récentes</string>
+  <string name="queries_per_minute_headline">Des requêtes DNS sont envoyées à chaque nouvelle connexion</string>
+  <string name="queries_per_minute_body">Cette valeur indique le nombre de requêtes DNS envoyées par votre appareil pendant la dernière minute.
+    Le chargement d\'une page Web complexe peut nécessiter plus d\'une centaine de requêtes DNS.</string>
   <string name="transport_label">Transport chiffré</string>
-  <string name="insecure_transport_label">Transport non chiffré</string>
+  <string name="transport_headline">Le chiffrement protège vos requêtes des regards indiscrets</string>
+  <string name="transport_body">Lorsque vous utilisez Intra, vos requêtes DNS sont chiffrées afin que seuls vous et le serveur DNS
+     puissiez les voir. Pour le chiffrement, Intra utilise le protocole HTTPS.</string>
+  <string name="default_transport_label">Trafic par défaut</string>
+  <string name="insecure_transport">non chiffré</string>
+  <string name="insecure_transport_headline">Les connexions DNS de base ne sont pas chiffrées</string>
+  <string name="insecure_transport_body">La plupart des appareils et des réseaux utilisent des connexions DNS de base, non chiffrées. Vos requêtes DNS peuvent donc être
+    observées et modifiées par toute personne sur le réseau. Certains appareils sont compatibles avec le protocole DNS sur TLS, qui
+    chiffre vos requêtes, mais n\'est pas en mesure de vous protéger en cas de connexion à un serveur malveillant.</string>
   <string name="server_label">Serveur DNS sécurisé</string>
-  <string name="insecure_server_label">Serveur DNS fourni par le réseau</string>
+  <string name="server_headline">Vous méritez un serveur DNS fiable</string>
+  <string name="server_body">Ce champ indique le nom du serveur DNS sécurisé que vous utilisez. Vous pouvez également changer de serveur
+    depuis le menu \"Paramètres\".</string>
+  <string name="default_server_label">Serveur DNS actuel</string>
+  <string name="insecure_server_headline">Vous pouvez choisir votre propre serveur DNS</string>
+  <string name="insecure_server_body">Quand Intra est désactivé, la plupart des appareils utilise par défaut le serveur DNS choisi par votre opérateur réseau. Ce champ indique l\'adresse IP du serveur DNS que votre appareil utilise actuellement. Avec Intra ou Android P, vous pouvez facilement sélectionner le serveur de votre choix.</string>
+  <string name="strict_mode_server_headline">Vous avez sélectionné un serveur sécurisé</string>
+  <string name="strict_mode_server_body">Ce champ indique le nom du serveur DNS que vous avez configuré dans le paramètre \"DNS privé\" d\'Android.  Quand Intra est désactivé, vos applications envoient les requêtes DNS à ce serveur.</string>
   <string name="unknown_server">(serveur inconnu)</string>
   <string name="show_history">Afficher les requêtes récentes</string>
   <string name="query_label">Requête</string>
@@ -72,11 +82,6 @@
     pas compatible avec Intra, vous pouvez l\'ajouter ici.</string>
   <string name="excluded_apps_title">Marquer les applications à exclure d\'Intra</string>
   <string name="old_android">Cette fonctionnalité n\'est pas disponible sur votre version d\'Android.</string>
-  <string name="before_feedback">Aidez-nous à améliorer Intra. Intra est une version préliminaire et nous avons besoin de vos commentaires pour l\'améliorer.
-    Indiquez-nous ce qui marche et ce qui ne marche pas. Merci !</string>
-  <string name="feedback_hint">Vos commentaires</string>
-  <string name="after_feedback">Ces commentaires vont être envoyés à l\'équipe Intra. Veuillez ne pas y inclure d\'informations personnelles.</string>
-  <string name="submit_feedback">Envoyer</string>
   <string name="notification_title">Protection DNS active</string>
   <string name="notification_content">Appuyez sur la notification pour modifier le paramètre relatif à la protection DNS</string>
   <string name="channel_name">Notification Protection DNS active</string>

--- a/Android/app/src/main/res/values-it/strings.xml
+++ b/Android/app/src/main/res/values-it/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Un percorso più sicuro per un Internet più libero</string>
-  <string name="intro_benefit_body">Quando utilizzi Internet, il dispositivo deve cercare gli indirizzi in un elenco di contatti Internet. A volte la connessione può fornirti un indirizzo errato.</string>
-  <string name="intro_manipulation_headline">Protezione dagli indirizzi errati</string>
-  <string name="intro_manipulation_body">Intra esegue la crittografia della tua connessione DNS proteggendoti dagli indirizzi errati che conducono a percorsi senza via d\'uscita (manipolazione del DNS).</string>
-  <string name="intro_details_headline">Per poter abilitare la protezione, Intra deve monitorare il traffico di rete</string>
-  <string name="intro_details_body">Per iniziare, tocca OK quando vedi la richiesta di connessione. Per impostazione predefinita, le tue query verranno inoltrate a Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Norme sulla privacy</a>). Puoi selezionare un altro servizio nelle impostazione dell\'app.</string>
+  <string name="intro_benefit_headline">Accesso a Internet più aperto</string>
+  <string name="intro_benefit_body">Intra ti protegge dalla manipolazione del DNS, un attacco informatico utilizzato per bloccare l\'accesso a siti di notizie, piattaforme di social media e app di messaggistica.\n\nIntra ti protegge dalla manipolazione del DNS, tuttavia esistono altri attacchi e tecniche di blocco più complicati contro cui non è efficace.</string>
+  <string name="intro_manipulation_headline">Protezione dalla manipolazione del DNS</string>
+  <string name="intro_manipulation_body">Intra protegge la tua connessione al DNS (Domain Name System), che fornisce gli indirizzi esatti per visitare un sito web o aprire un\'app.\n\nIntra usa la crittografia per verificare che i risultati non possano essere manipolati, garantendo l\'accesso sicuro a Internet.</string>
+  <string name="intro_details_headline">Un\'ultima cosa…</string>
+  <string name="intro_details_body">Tocca OK per consentire a Intra di proteggere le tue richieste DNS, che verranno inoltrate per impostazione predefinita a Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Norme sulla privacy</a>). Puoi selezionare un altro servizio nelle impostazioni dell\'app.</string>
   <string name="intro_back">Indietro</string>
   <string name="intro_next">Avanti</string>
   <string name="intro_accept">Accetta</string>
-  <string name="about_headline">DNS affidabile e sicuro</string>
-  <string name="about_text">Intra protegge le query DNS inviandole tramite una connessione HTTPS sicura. In questo modo si riducono le possibilità di essere reindirizzati al sito sbagliato o di essere bloccati o controllati durante la navigazione.</string>
-  <string name="privacy_text">Per impostazione predefinita, le tue query verranno inoltrate a
-    <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Norme sulla privacy</a>).
-    Puoi anche utilizzare <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Norme sulla privacy</a>)
-    o qualsiasi altro servizio DNS-over-HTTPS.</string>
-  <string name="accept">Inizia</string>
   <string name="drawer_open">Apri il riquadro di navigazione a scomparsa</string>
   <string name="drawer_close">Chiudi il riquadro di navigazione a scomparsa</string>
   <string name="home">Home</string>
   <string name="settings">Impostazioni</string>
-  <string name="feedback">Invia feedback</string>
   <string name="support">Assistenza</string>
   <string name="privacy_link">Norme sulla privacy</string>
   <string name="tos_link">Termini di servizio</string>
   <string name="source_code">Codice sorgente</string>
-  <string name="short_credits_text">Intra è un progetto open source sperimentale di <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra è un\'app realizzata da <a href="https://jigsaw.google.com">Jigsaw</a>. La localizzazione degli indirizzi IP si basa sui dati di DB-IP.com.</string>
   <string name="indicator_on">Attiva</string>
   <string name="indicator_off">Disattiva</string>
@@ -35,25 +24,44 @@
   <string name="status_protected">Protette</string>
   <string name="explanation_protected">La tua connessione è protetta dagli attacchi al DNS.</string>
   <string name="status_upgraded">Vulnerabile</string>
-  <string name="explanation_upgraded">Attualmente la tua connessione è protetta dall\'impostazione DNS privato di Android, ma un utente malintenzionato potrebbe disattivare
-    o danneggiare questa protezione.</string>
+  <string name="explanation_upgraded">Attualmente la tua connessione è protetta dall\'impostazione DNS privato di Android, ma un utente malintenzionato potrebbe disattivare o danneggiare questa protezione.</string>
   <string name="status_strict">Protette da Android</string>
-  <string name="explanation_strict">Intra ha rilevato che è attiva l\'impostazione DNS privato di Android. Ciò significa che le tue query
-    DNS sono già protette, pertanto non è necessario attivare Intra.</string>
+  <string name="explanation_strict">Intra ha rilevato che è attiva l\'impostazione DNS privato di Android. Ciò significa che le tue query DNS sono già protette, pertanto non è necessario attivare Intra.</string>
   <string name="status_starting">Avvio in corso…</string>
-  <string name="explanation_starting">Attendi.  Intra sta stabilendo una connessione al server.</string>
+  <string name="explanation_starting">Attendi. Intra sta stabilendo una connessione al server.</string>
   <string name="status_waiting">In attesa…</string>
-  <string name="explanation_offline">Il tuo dispositivo è offline.  Intra è in attesa di una connessione di rete.</string>
-  <string name="explanation_vpn">Intra ha rilevato un\'altra VPN sul tuo dispositivo. Se attivi Intra, questa VPN verrà disattivata.
-    Intra non è sicura quanto una VPN certificata.</string>
-  <string name="explanation_failing">Avviso: le query stanno restituendo un errore.  Ti consigliamo di scegliere un server diverso e riavviare Intra.</string>
+  <string name="explanation_offline">Il tuo dispositivo è offline. Intra è in attesa di una connessione di rete.</string>
+  <string name="explanation_vpn">Intra ha rilevato un\'altra VPN sul tuo dispositivo. Se attivi Intra, questa VPN verrà disattivata. Intra non è sicura quanto una VPN certificata.</string>
+  <string name="explanation_failing">Avviso: le query stanno restituendo un errore. Ti consigliamo di scegliere un server diverso e riavviare Intra.</string>
   <string name="system_details">Dettagli del sistema</string>
   <string name="num_requests">Query con durata predefinita</string>
+  <string name="num_requests_headline">Le query DNS si verificano quando il tuo dispositivo cerca gli indirizzi IP per un nome di dominio</string>
+  <string name="num_requests_body">Questo valore mostra il numero totale di query DNS che il tuo dispositivo ha eseguito mentre Intra era
+    attivo. Intra cripta queste query e le invia a un server certificato per assicurarsi che tu
+    ottenga risultati autentici.</string>
   <string name="queries_per_minute">Query recenti</string>
+  <string name="queries_per_minute_headline">Le query DNS vengono eseguite all\'inizio di ogni connessione</string>
+  <string name="queries_per_minute_body">Questo valore mostra il numero totale di query DNS che il tuo dispositivo ha eseguito nell\'ultimo minuto.
+    Il caricamento di una pagina web complessa potrebbe richiedere più di 100 query DNS.</string>
   <string name="transport_label">Trasferimento crittografato</string>
-  <string name="insecure_transport_label">Trasferimento non crittografato</string>
+  <string name="transport_headline">La crittografia protegge le query da occhi indiscreti</string>
+  <string name="transport_body">Quando usi Intra, le query DNS che esegui vengono criptate, in modo che solo tu e il server DNS
+    possiate vederle. Intra implementa DNS sul protocollo HTTPS per la crittografia.</string>
+  <string name="default_transport_label">Trasporto predefinito</string>
+  <string name="insecure_transport">non criptato</string>
+  <string name="insecure_transport_headline">DNS di base non è criptato</string>
+  <string name="insecure_transport_body">La maggior parte dei dispositivi e delle reti usa DNS di base, che non è criptato, quindi le query DNS potrebbero essere
+    osservate o modificate da chiunque sulla rete. Alcuni nuovi dispositivi supportano DNS su TLS, che
+    cripta le tue query ma non può proteggerti se il server è potenzialmente pericoloso.</string>
   <string name="server_label">Server DNS sicuro</string>
-  <string name="insecure_server_label">Server DNS fornito dalla rete</string>
+  <string name="server_headline">È opportuno usare un server DNS affidabile</string>
+  <string name="server_body">Questo campo mostra il nome del server DNS sicuro in uso. Puoi impostare un
+    server diverso nel menu Impostazioni.</string>
+  <string name="default_server_label">Server DNS attuale</string>
+  <string name="insecure_server_headline">Puoi scegliere un server DNS personalizzato</string>
+  <string name="insecure_server_body">Quando Intra è disattivato, la maggior parte dei dispositivi sono pre-configurati per utilizzare il server DNS scelto dall\'operatore di rete. Questo campo mostra l\'indirizzo IP del server DNS utilizzato al momento dal dispositivo. Con Intra o Android P, puoi facilmente selezionare il server che preferisci.</string>
+  <string name="strict_mode_server_headline">Hai selezionato un server sicuro</string>
+  <string name="strict_mode_server_body">Questo campo mostra il nome del server DNS configurato nell\'impostazione DNS privato di Android.  Quando Intra è disattivato, le app devono inviare le query DNS a questo server.</string>
   <string name="unknown_server">(server sconosciuto)</string>
   <string name="show_history">Mostra query recenti</string>
   <string name="query_label">Query</string>
@@ -70,10 +78,6 @@
     incompatibile con Intra, puoi aggiungerla di seguito.</string>
   <string name="excluded_apps_title">Selezionare le app da escludere da Intra</string>
   <string name="old_android">Questa funzionalità non è disponibile per la tua versione Android.</string>
-  <string name="before_feedback">Aiutaci a migliorare Intra. Intra è un prodotto in fase iniziale di sviluppo e abbiamo bisogno del tuo aiuto per migliorarlo. Scrivici cosa funziona e cosa no. Grazie.</string>
-  <string name="feedback_hint">Il tuo feedback</string>
-  <string name="after_feedback">Queste informazioni saranno inviate al team Intra. Non includere dati personali nel feedback.</string>
-  <string name="submit_feedback">Invia</string>
   <string name="notification_title">La protezione DNS è attiva</string>
   <string name="notification_content">Tocca per modificare le impostazioni di protezione DNS</string>
   <string name="channel_name">Notifica protezione DNS attiva</string>

--- a/Android/app/src/main/res/values-ja/strings.xml
+++ b/Android/app/src/main/res/values-ja/strings.xml
@@ -1,27 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">よりオープンなインターネットへは、より安全なルートで</string>
-  <string name="intro_benefit_body">インターネットを使う端末は、インターネットの連絡先リストに含まれるアドレスを調べるため、場合によっては、接続で不正なアドレスが取得されることがあります。</string>
-  <string name="intro_manipulation_headline">不正なアドレスからの保護</string>
-  <string name="intro_manipulation_body">Intra は DNS 接続を暗号化することによって、間違ったサイトに誘導する（DNS 操作）不正アドレスを取得しないように保護します。</string>
-  <string name="intro_details_headline">保護を有効にするには、Intra でネットワーク トラフィックをモニタリングする必要があります</string>
-  <string name="intro_details_body">開始するための接続リクエストが表示されたら [OK] をタップします。デフォルトでは、クエリは Google Public DNS（<a href="https://developers.google.com/speed/public-dns/privacy">プライバシー ポリシー</a>）にルーティングされます。アプリの設定で他のサービスを選択することもできます。</string>
+  <string name="intro_benefit_headline">よりオープンなインターネットへのアクセス</string>
+  <string name="intro_benefit_body">Intra を使用すると、DNS 操作（ニュースサイト、ソーシャル メディア プラットフォーム、メッセージ アプリへのアクセスをブロックするサイバー攻撃）から保護されます。\n\nDNS 操作からは保護されますが、その他に複雑なブロック技術や攻撃方法が存在し、Intra はそれらには対応していません。</string>
+  <string name="intro_manipulation_headline">DNS 操作からの保護</string>
+  <string name="intro_manipulation_body">Intra により、ウェブサイトにアクセスしたり、アプリを開いたりする際に必要な IP アドレスを提供するドメインネーム システム（DNS）への接続が保護されます。\n\nIntra を使用すると暗号化によって接続が操作されないように保護され、インターネットに安全にアクセスできるようになります。</string>
+  <string name="intro_details_headline">権限とプライバシー</string>
+  <string name="intro_details_body">[OK] をタップすると、DNS リクエストが保護されるようになります。デフォルトでは、リクエストは Google Public DNS（<a href="https://developers.google.com/speed/public-dns/privacy">プライバシー ポリシー</a>）にルーティングされます。アプリの設定で他のサービスを選択することもできます。</string>
   <string name="intro_back">戻る</string>
   <string name="intro_next">次へ</string>
   <string name="intro_accept">同意する</string>
-  <string name="about_headline">信頼性が高く、安全な DNS</string>
-  <string name="about_text">Intra は安全な HTTPS 接続を経由してルーティングすることで、DNS クエリを保護します。これにより、間違ったサイトに送信される可能性が減り、ブラウジングがブロックされたり監視されたりすることも少なくなります。</string>
-  <string name="privacy_text">デフォルトでは、クエリは <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>（<a href="https://developers.google.com/speed/public-dns/privacy">プライバシー ポリシー</a>）にルーティングされます。<a href="https://cloudflare-dns.com">Cloudflare</a>（<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">プライバシー ポリシー</a>）またはその他の任意の DNS over HTTPS サービスを使用することもできます。</string>
-  <string name="accept">使ってみる</string>
   <string name="drawer_open">ナビゲーション ドロワーを開く</string>
   <string name="drawer_close">ナビゲーション ドロワーを閉じる</string>
   <string name="home">ホーム</string>
   <string name="settings">設定</string>
-  <string name="feedback">フィードバックを送信</string>
   <string name="support">サポート</string>
   <string name="privacy_link">プライバシー ポリシー</string>
   <string name="tos_link">利用規約</string>
   <string name="source_code">ソースコード</string>
-  <string name="short_credits_text">Intra は <a href="https://jigsaw.google.com">Jigsaw</a> による試験運用段階のオープンソース プロジェクトです。</string>
   <string name="credits_text">Intra は <a href="https://jigsaw.google.com">Jigsaw</a> で開発されたものです。IP 位置情報は DB-IP.com から取得したデータに基づいています。</string>
   <string name="indicator_on">オン</string>
   <string name="indicator_off">オフ</string>
@@ -44,11 +38,33 @@
   <string name="explanation_failing">警告: クエリが失敗しています。別のサーバーを選択して Intra を再起動することをおすすめします。</string>
   <string name="system_details">システムの詳細</string>
   <string name="num_requests">これまでのクエリ</string>
+  <string name="num_requests_headline">IP アドレスでドメイン名を検索すると DNS クエリが発生</string>
+  <string name="num_requests_body">この値は、Intra がアクティブになっている間にデバイスで実行された DNS クエリの合計数を
+    表します。Intra によってこれらのクエリが暗号化され、信頼済みのサーバーに送信され
+    適切なクエリ結果が得られるようになります。</string>
   <string name="queries_per_minute">最近のクエリ</string>
+  <string name="queries_per_minute_headline">DNS クエリは接続の開始時に発生</string>
+  <string name="queries_per_minute_body">この値は、最後の 1 分間にデバイスで実行された DNS クエリの数を表します。
+    複雑なウェブページの読み込みの場合、100 件以上の DNS クエリが発生することがあります。</string>
   <string name="transport_label">暗号化された通信</string>
-  <string name="insecure_transport_label">暗号化されていない通信</string>
+  <string name="transport_headline">暗号化によって不正な操作からクエリを保護</string>
+  <string name="transport_body">Intra を使用すると、DNS クエリが暗号化され、ユーザーと該当の DNS サーバーのみが
+    DNS クエリの内容を認識することができます。Intra には、DNS over HTTPS プロトコルが実装され、暗号化に対応しています。</string>
+  <string name="default_transport_label">デフォルトの通信</string>
+  <string name="insecure_transport">暗号化なし</string>
+  <string name="insecure_transport_headline">基本的な DNS は暗号化に未対応</string>
+  <string name="insecure_transport_body">ほとんどのデバイスとネットワークでは暗号化に対応しない、基本的な DNS が使用されています。そのため、ネットワークで何者かによって DNS クエリが
+    監視または変更される恐れがあります。新しいデバイスの中には、DNS over TLS をサポートするものがあります。
+    DNS over TLS ではクエリが暗号化されますが、信頼できないサーバーの場合、通信は保護されません。</string>
   <string name="server_label">安全な DNS サーバー</string>
-  <string name="insecure_server_label">ネットワークから提供された DNS サーバー</string>
+  <string name="server_headline">信頼できる DNS サーバーの使用</string>
+  <string name="server_body">この欄にはユーザーが使用している安全な DNS サーバーの名前が表示されます。[設定] メニューで
+    別のサーバーに変更することもできます。</string>
+  <string name="default_server_label">現在の DNS サーバー</string>
+  <string name="insecure_server_headline">独自の DNS サーバーを選択できます</string>
+  <string name="insecure_server_body">Intra が無効になっている場合、ほとんどのデバイスは、ネットワークの運用担当者が選択した DNS サーバーを使用するように事前に設定されています。この項目には、お使いのデバイスで現在使用している DNS サーバーの IP アドレスが表示されます。Intra や Android P を使用して、お好きなサーバーを簡単に選択できます。</string>
+  <string name="strict_mode_server_headline">安全なサーバーを選択しました</string>
+  <string name="strict_mode_server_body">この項目には、Android のプライベート DNS で設定された DNS サーバーの名前が表示されます。Intra が無効になっている場合、このサーバーに対してアプリから DNS クエリを送信する必要があります。</string>
   <string name="unknown_server">（不明なサーバー）</string>
   <string name="show_history">最近のクエリを表示する</string>
   <string name="query_label">クエリ</string>
@@ -64,10 +80,6 @@
   <string name="excluded_apps_summary">選択したアプリの DNS クエリは Intra を利用しません。アプリが Intra に対応していないと思われる場合は、ここで追加できます。</string>
   <string name="excluded_apps_title">Intra の対象外とするアプリの指定</string>
   <string name="old_android">この機能は、お使いの Android のバージョンではご利用いただけません。</string>
-  <string name="before_feedback">Intra の改善にご協力ください。Intra は初期段階のサービスであるため、改善にご協力いただけると幸いです。良かった点や改善してほしい点についてご意見をお聞かせください。どうぞよろしくお願いいたします。</string>
-  <string name="feedback_hint">フィードバック</string>
-  <string name="after_feedback">この情報は Intra チームに送信されます。フィードバックに個人情報を含めないようにしてください。</string>
-  <string name="submit_feedback">送信</string>
   <string name="notification_title">DNS 保護が有効です</string>
   <string name="notification_content">タップすると、DNS 保護の設定が変わります</string>
   <string name="channel_name">DNS 保護が有効な場合の通知</string>

--- a/Android/app/src/main/res/values-ko/strings.xml
+++ b/Android/app/src/main/res/values-ko/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">더욱 개방된 인터넷에 대한 더욱 안전한 연결 경로</string>
-  <string name="intro_benefit_body">인터넷을 사용할 때 기기는 인터넷 주소 목록에서 주소를 검색해야 하는데 잘못된 주소로 연결되는 경우가 있습니다.</string>
-  <string name="intro_manipulation_headline">잘못된 주소로부터 보호</string>
-  <string name="intro_manipulation_body">Intra는 DNS 연결을 암호화하여 DNS 조작을 통해 막다른 길로 이어지는 잘못된 주소에 연결되지 않도록 보호합니다.</string>
-  <string name="intro_details_headline">Intra는 보호를 위해 네트워크 트래픽을 모니터링해야 합니다.</string>
-  <string name="intro_details_body">시작하려면 연결 요청이 표시될 때 확인을 탭하세요. 쿼리는 기본적으로 Google Public DNS로 라우트됩니다(<a href="https://developers.google.com/speed/public-dns/privacy">개인정보처리방침</a>). 앱 설정에서 다른 서비스를 선택할 수 있습니다.</string>
+  <string name="intro_benefit_headline">더욱 자유로운 인터넷 액세스</string>
+  <string name="intro_benefit_body">Intra는 뉴스 사이트, 소셜 미디어 플랫폼, 메시지 앱에 액세스하지 못하게 차단하는 사이버 공격인 DNS 조작으로부터 사용자를 보호합니다.\n\n하지만 DNS 조작보다 복잡한 차단 기법 및 공격으로부터 보호해 주지는 못합니다.</string>
+  <string name="intro_manipulation_headline">DNS 조작으로부터 보호</string>
+  <string name="intro_manipulation_body">Intra는 웹사이트를 방문하거나 앱을 여는 데 필요한 정확한 주소를 제공하는 DNS(도메인 이름 시스템)에 대한 연결을 보호해 줍니다.\n\n또한 결과가 조작되지 않도록 암호화를 활용하여 사용자가 인터넷에 안전하게 액세스하도록 도와줍니다.</string>
+  <string name="intro_details_headline">마지막으로 하나만 더 확인해 주세요</string>
+  <string name="intro_details_body">Intra가 DNS 요청을 보호하도록 허용하려면 확인을 탭하세요. DNS 요청은 기본적으로 Google Public DNS로 라우팅됩니다(<a href="https://developers.google.com/speed/public-dns/privacy">개인정보처리방침</a>). 앱 설정에서 다른 서비스를 선택할 수 있습니다.</string>
   <string name="intro_back">뒤로</string>
   <string name="intro_next">다음</string>
   <string name="intro_accept">동의</string>
-  <string name="about_headline">정직하고 안전한 DNS</string>
-  <string name="about_text">Intra는 안전한 HTTPS 연결을 통해 DNS 쿼리를 라우트하여 쿼리를 보호합니다. 이를 통해
-    잘못된 사이트로 이동되거나 인터넷 탐색이 차단 또는 감시될 가능성이 줄어듭니다.</string>
-  <string name="privacy_text">쿼리는 기본적으로
-    <a href="https://developers.google.com/speed/public-dns/">Google 공개 DNS</a>로 라우트됩니다.
-    (<a href="https://developers.google.com/speed/public-dns/privacy">개인정보처리방침</a>).
-    또한 <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">개인정보처리방침</a>)
-    또는 다른 HTTPS를 통한 DNS 서비스를 사용할 수 있습니다.</string>
-  <string name="accept">시작하기</string>
   <string name="drawer_open">탐색 창 열기</string>
   <string name="drawer_close">탐색 창 닫기</string>
   <string name="home">홈</string>
   <string name="settings">설정</string>
-  <string name="feedback">의견 보내기</string>
   <string name="support">지원</string>
   <string name="privacy_link">개인정보처리방침</string>
   <string name="tos_link">이용 약관</string>
   <string name="source_code">소스 코드</string>
-  <string name="short_credits_text">Intra는 <a href="https://jigsaw.google.com">Jigsaw</a>에서 진행하는 실험적인 오픈소스 프로젝트입니다.</string>
   <string name="credits_text">Intra는 <a href="https://jigsaw.google.com">Jigsaw</a>에서 제작했습니다. IP 위치는
     DB-IP.com의 데이터를 기반으로 합니다.</string>
   <string name="indicator_on">켬</string>
@@ -51,11 +39,36 @@
   <string name="explanation_failing">경고: 쿼리에 실패했습니다. 다른 서버를 선택하여 Intra를 다시 시작할 수 있습니다.</string>
   <string name="system_details">시스템 세부정보</string>
   <string name="num_requests">지금까지 보호된 쿼리 수</string>
+  <string name="num_requests_headline">DNS 쿼리는 기기에서 도메인 이름의 IP 주소를 조회할 때 생성됩니다.</string>
+  <string name="num_requests_body">이 값은 Intra가 활성화되었을 때 기기에서 실행된 총 DNS 쿼리 수를 나타냅니다.
+    Intra는 사용자가 조작되지 않은 결과를 얻을 수 있도록 이러한 쿼리를 암호화하여 신뢰할
+    수 있는 서버로 전송합니다.</string>
   <string name="queries_per_minute">최근 보호된 쿼리 수</string>
+  <string name="queries_per_minute_headline">DNS 쿼리는 각 연결의 시작 부분에서 생성됩니다.</string>
+  <string name="queries_per_minute_body">이 값은 기기가 지난 1분 동안 실행한 DNS 쿼리 수를 나타냅니다.
+    복잡한 웹페이지를 로드하는 데는 100회가 넘는 DNS 쿼리가 필요할 수도 있습니다.</string>
   <string name="transport_label">암호화된 전송</string>
-  <string name="insecure_transport_label">암호화되지 않은 전송</string>
+  <string name="transport_headline">암호화를 통해 감시로부터 쿼리 보호</string>
+  <string name="transport_body">Intra를 사용하면 DNS 쿼리가 암호화되므로 사용자의 DNS
+    쿼리가 본인 및 DNS 서버에만 공개됩니다. Intra는 암호화를 위해 HTTPS를 통한 DNS 프로토콜을 구현합니다.</string>
+  <string name="default_transport_label">기본 전송</string>
+  <string name="insecure_transport">암호화되지 않음</string>
+  <string name="insecure_transport_headline">기본 DNS는 암호화되지 않습니다.</string>
+  <string name="insecure_transport_body">대부분의 기기 및 네트워크에서는 암호화되지 않은 기본 DNS가 사용되므로 네트워크에 접속한 누구라도
+    사용자의 DNS 쿼리를 보거나 수정할 수 있습니다. 일부 최신 기기에서는 TLS를 통한 DNS를 지원하여
+    쿼리를 암호화하지만, 악성 서버로부터 사용자를 보호해 주지는 못합니다.</string>
   <string name="server_label">보안 DNS 서버</string>
-  <string name="insecure_server_label">네트워크 제공 DNS 서버</string>
+  <string name="server_headline">신뢰할 수 있는 DNS 서버 사용</string>
+  <string name="server_body">이 입력란에는 사용 중인 보안 DNS 서버의 이름이 표시됩니다. 설정 메뉴에서
+    서버를 변경할 수도 있습니다.</string>
+  <string name="default_server_label">현재 DNS 서버</string>
+  <string name="insecure_server_headline">나의 DNS 서버를 선택할 수 있습니다.</string>
+  <string name="insecure_server_body">대부분의 기기는 Intra가 사용 중지되는 경우 네트워크 제공업체에서 선택한 DNS 서버를 사용하도록
+    사전에 구성되어 있습니다. 이 입력란에는 기기에서 현재 사용 중인 DNS 서버의 IP 주소가
+    표시됩니다. Intra 또는 Android P를 사용하면 원하는 서버를 간편하게 선택할 수 있습니다.</string>
+  <string name="strict_mode_server_headline">안전한 서버를 선택했습니다.</string>
+  <string name="strict_mode_server_body">이 입력란에는 Android 비공개 DNS 설정에서 구성한 DNS 서버의 이름이
+    표시됩니다.  Intra가 사용 중지되면 앱에서 DNS 쿼리를 이 서버로 전송합니다.</string>
   <string name="unknown_server">(알 수 없는 서버)</string>
   <string name="show_history">최근 쿼리 보기</string>
   <string name="query_label">쿼리</string>
@@ -72,12 +85,6 @@
     있으면 여기에 추가할 수 있습니다.</string>
   <string name="excluded_apps_title">Intra에서 제외할 앱 설정</string>
   <string name="old_android">사용 중인 Android 버전에서는 이 기능을 사용할 수 없습니다.</string>
-  <string name="before_feedback">Intra 개선에 참여해 주세요. 아직 초기 단계에 있는 제품인 Intra를 개선하려면 여러분의 도움이 필요합니다.
-    좋은 점과 개선해야 할 부분을 알려 주시면 감사하겠습니다.</string>
-  <string name="feedback_hint">의견</string>
-  <string name="after_feedback">입력하신 정보는 Intra팀에 전송됩니다. 의견에 개인정보를 포함하지
-    마세요.</string>
-  <string name="submit_feedback">제출</string>
   <string name="notification_title">DNS 보호가 활성화됨</string>
   <string name="notification_content">DNS 보호 설정을 변경하려면 탭하세요.</string>
   <string name="channel_name">DNS 보호 활성화 알림</string>

--- a/Android/app/src/main/res/values-nl/strings.xml
+++ b/Android/app/src/main/res/values-nl/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Een veilige route naar een opener internet</string>
-  <string name="intro_benefit_body">Wanneer je internet gebruikt, moet je apparaat adressen opzoeken in een contactenlijst op internet. Soms wordt het verkeerde adres doorgegeven.</string>
-  <string name="intro_manipulation_headline">Bescherming tegen verkeerde adressen</string>
-  <string name="intro_manipulation_body">Met Intra wordt je DNS-verbinding versleuteld, zodat je beschermd bent tegen verkeerde adressen die leiden tot dead ends (DNS-manipulatie).</string>
-  <string name="intro_details_headline">Intra moet netwerkverkeer controleren om je te kunnen beschermen</string>
-  <string name="intro_details_body">Tik wanneer je het verbindingsverzoek ziet op OK om aan de slag te gaan. Standaard worden je zoekopdrachten gerouteerd door de Openbare DNS van Google (<a href="https://developers.google.com/speed/public-dns/privacy">Privacybeleid</a>). Je kunt een andere service kiezen in de app-instellingen.</string>
+  <string name="intro_benefit_headline">Opener internettoegang</string>
+  <string name="intro_benefit_body">Intra beschermt je tegen DNS-manipulatie, een cyberaanval waarbij de toegang tot nieuwssites, social media-platforms en berichten-apps wordt geblokkeerd.\n\nHoewel Intra je beschermt tegen DNS-manipulatie, zijn er andere, ingewikkeldere technieken en aanvallen waartegen Intra geen bescherming biedt.</string>
+  <string name="intro_manipulation_headline">Bescherming tegen DNS-manipulatie</string>
+  <string name="intro_manipulation_body">Intra beschermt je verbinding met het Domain Name System (DNS). DNS levert de exacte adressen waarmee je een website kunt bezoeken of een app kunt openen.\n\nIntra versleutelt resultaten, zodat deze niet kunnen worden gemanipuleerd en je veilig blijft op internet.</string>
+  <string name="intro_details_headline">Nog iets…</string>
+  <string name="intro_details_body">Tik op OK om Intra toe te staan je DNS-verzoeken te beschermen. Deze worden standaard gerouteerd door de openbare DNS van Google (<a href="https://developers.google.com/speed/public-dns/privacy">privacybeleid</a>). Je kunt een andere service kiezen in de app-instellingen.</string>
   <string name="intro_back">vorige</string>
   <string name="intro_next">volgende</string>
   <string name="intro_accept">accepteren</string>
-  <string name="about_headline">Eerlijke en veilige DNS</string>
-  <string name="about_text">Intra beschermt je DNS-zoekopdrachten door deze over een veilige https-verbinding te leiden. Hierdoor is er minder kans dat je naar de verkeerde site wordt geleid, dat het browsen wordt geblokkeerd of dat ermee wordt meegekeken.</string>
-  <string name="privacy_text">Standaard worden je zoekopdrachten gerouteerd naar
-    <a href="https://developers.google.com/speed/public-dns/">de openbare DNS van Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">privacybeleid</a>).
-    Je kunt er ook voor kiezen <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">privacybeleid</a>)
-    of een andere DNS-over-HTTPS-service te gebruiken.</string>
-  <string name="accept">Aan de slag</string>
   <string name="drawer_open">Zijmenu openen</string>
   <string name="drawer_close">Zijmenu sluiten</string>
   <string name="home">Home</string>
   <string name="settings">Instellingen</string>
-  <string name="feedback">Feedback verzenden</string>
   <string name="support">Ondersteuning</string>
   <string name="privacy_link">Privacybeleid</string>
   <string name="tos_link">Algemene voorwaarden</string>
   <string name="source_code">Broncode</string>
-  <string name="short_credits_text">Intra is een experimenteel open-sourceproject van <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra is gemaakt door <a href="https://jigsaw.google.com">Jigsaw</a>. IP-locaties worden gebaseerd op gegevens van DB-IP.com.</string>
   <string name="indicator_on">Ingeschakeld</string>
   <string name="indicator_off">Uitgeschakeld</string>
@@ -46,11 +35,26 @@
   <string name="explanation_failing">Waarschuwing: Zoekopdrachten mislukken. Kies een andere server en start Intra opnieuw.</string>
   <string name="system_details">Systeemgegevens</string>
   <string name="num_requests">Aantal zoekopdrachten</string>
+  <string name="num_requests_headline">DNS-zoekopdrachten vinden plaats wanneer je apparaat het IP-adres van een domeinnaam opzoekt</string>
+  <string name="num_requests_body">Deze waarde geeft het aantal DNS-zoekopdrachten aan die zijn uitgevoerd toen Intra actief was. Intra versleutelt deze zoekopdrachten en stuurt ze naar een vertrouwde server. Zo zie je alleen authentieke resultaten.</string>
   <string name="queries_per_minute">Recente zoekopdrachten</string>
+  <string name="queries_per_minute_headline">DNS-zoekopdrachten worden uitgevoerd aan het begin van elke verbinding</string>
+  <string name="queries_per_minute_body">Deze waarde geeft het aantal DNS-zoekopdrachten aan die in de afgelopen minuut zijn uitgevoerd op je apparaat. Er kunnen meer dan honderd DNS-zoekopdrachten plaatsvinden om een complexe webpagina te openen.</string>
   <string name="transport_label">Versleuteld transport</string>
-  <string name="insecure_transport_label">Niet-versleuteld transport</string>
+  <string name="transport_headline">Je zoekopdrachten zijn beschermd tegen vreemde ogen dankzij versleuteling</string>
+  <string name="transport_body">Wanneer je Intra gebruikt, worden je DNS-zoekopdrachten versleuteld, zodat alleen jij en je DNS-server kunnen zien welke DNS-zoekopdrachten je uitvoert. Intra implementeert het DNS-over-HTTPS-protocol voor versleuteling.</string>
+  <string name="default_transport_label">Standaardtransport</string>
+  <string name="insecure_transport">onversleuteld</string>
+  <string name="insecure_transport_headline">Basis-DNS is onversleuteld</string>
+  <string name="insecure_transport_body">De meeste apparaten en netwerken gebruiken basis-DNS. Deze versie is onversleuteld, je DNS-zoekopdrachten kunnen dus worden bekeken of aangepast door iedereen in het netwerk. Op sommige nieuwe apparaten wordt DNS-over-TLS ondersteund. Hiermee worden zoekopdrachten versleuteld, maar ben je niet beschermd tegen zakelijke servers.</string>
   <string name="server_label">Veilige DNS-server</string>
-  <string name="insecure_server_label">Door netwerk geleverde DNS-server</string>
+  <string name="server_headline">Je verdient een betrouwbare DNS-server</string>
+  <string name="server_body">In dit veld staat de naam van de veilige DNS-server die je gebruikt. Je kunt deze wijzigen in een andere server in het menu Instellingen.</string>
+  <string name="default_server_label">Huidige DNS-server</string>
+  <string name="insecure_server_headline">Je kunt je eigen DNS-server kiezen</string>
+  <string name="insecure_server_body">Wanneer Intra is uitgeschakeld, geldt voor de meeste apparaten dat deze zo zijn geconfigureerd dat de DNS-server wordt gebruikt die wordt gekozen door je netwerkoperator. In dit veld staat het IP-adres van de DNS-server die je apparaat momenteel gebruikt. Met Intra of Android P kun je eenvoudig een server kiezen.</string>
+  <string name="strict_mode_server_headline">Je hebt een veilige server geselecteerd</string>
+  <string name="strict_mode_server_body">In dit veld staat de naam van de DNS-server die je hebt geconfigureerd in de instelling \'Privé DNS\' van Android.  Wanneer Intra is ingeschakeld, sturen je apps DNS-zoekopdrachten naar deze server.</string>
   <string name="unknown_server">(onbekende server)</string>
   <string name="show_history">Recente zoekopdrachten weergeven</string>
   <string name="query_label">Zoekopdracht</string>
@@ -67,10 +71,6 @@
     met Intra, kun je die hier toevoegen.</string>
   <string name="excluded_apps_title">Apps markeren die Intra niet moeten gebruiken</string>
   <string name="old_android">Deze functie is niet beschikbaar in jouw versie van Android.</string>
-  <string name="before_feedback">Help ons Intra te verbeteren. Intra zit nog in de beginfase. We hebben je hulp nodig om het nog beter te maken. Laat ons weten wat er goed werkt en wat er niet goed werkt. Bedankt!</string>
-  <string name="feedback_hint">Je feedback</string>
-  <string name="after_feedback">Deze informatie wordt verzonden naar Team Intra. Voeg geen persoonlijke gegevens toe aan je feedback.</string>
-  <string name="submit_feedback">Verzenden</string>
   <string name="notification_title">DNS-bescherming is actief</string>
   <string name="notification_content">Tik hier om de instelling voor DNS-bescherming te wijzigen</string>
   <string name="channel_name">Melding \'DNS-bescherming actief\'</string>

--- a/Android/app/src/main/res/values-pl/strings.xml
+++ b/Android/app/src/main/res/values-pl/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Bezpieczniejszy i szerszy dostęp do internetu</string>
-  <string name="intro_benefit_body">Gdy korzystasz z internetu, Twoje urządzenie wyszukuje adresy w internetowej liście kontaktów. Czasami połączenie może zwrócić nieprawidłowy adres.</string>
-  <string name="intro_manipulation_headline">Ochrona przed nieprawidłowymi adresami</string>
-  <string name="intro_manipulation_body">Intra zapewnia ochronę przed pobieraniem nieprawidłowych adresów, które prowadzą do ślepych zaułków (manipulacja rekordami DNS), szyfrując Twoje połączenie DNS.</string>
-  <string name="intro_details_headline">Intra monitoruje ruch w sieci, by zapewnić ochronę</string>
-  <string name="intro_details_body">Gdy zobaczysz prośbę o połączenie, kliknij OK, by rozpocząć. Zapytania będą domyślnie kierowane do publicznego serwera DNS Google (<a href="https://developers.google.com/speed/public-dns/privacy">Polityka prywatności</a>). Możesz też wybrać inną usługę w ustawieniach aplikacji.</string>
+  <string name="intro_benefit_headline">Bardziej otwarty dostęp do internetu</string>
+  <string name="intro_benefit_body">Intra chroni Cię przed manipulacją DNS – atakiem sieciowym używanym do blokowania dostępu do serwisów z wiadomościami, mediów społecznościowych i komunikatorów.\n\nIstnieją jednak inne, bardziej skomplikowane techniki blokowania i ataki, przed którymi Intra nie chroni.</string>
+  <string name="intro_manipulation_headline">Ochrona przed manipulacją DNS</string>
+  <string name="intro_manipulation_body">Intra chroni Twoje połączenie z systemem nazw domenowych (DNS), z którego otrzymujesz dokładne adresy potrzebne do otwierania stron internetowych i aplikacji.\n\nIntra stosuje szyfrowanie, by zapobiec manipulowaniu wynikami, pomagając Ci bezpiecznie korzystać z internetu.</string>
+  <string name="intro_details_headline">Jeszcze jedno…</string>
+  <string name="intro_details_body">Kliknij OK, by zezwolić aplikacji Intra na chronienie Twoich żądań DNS. Domyślnie będą one kierowane do publicznego serwera DNS Google (<a href="https://developers.google.com/speed/public-dns/privacy">Polityka prywatności</a>). W ustawieniach aplikacji możesz wybrać inną usługę.</string>
   <string name="intro_back">wstecz</string>
   <string name="intro_next">dalej</string>
   <string name="intro_accept">akceptuj</string>
-  <string name="about_headline">Uczciwy i bezpieczny DNS</string>
-  <string name="about_text">Intra chroni Twoje zapytania DNS, przesyłając je przez bezpieczne połączenie HTTPS. Zmniejsza to ryzyko, że ktoś
-    przekieruje Cię na niewłaściwą stronę, zablokuje dostęp do określonych stron lub będzie śledzić Twoją aktywność.</string>
-  <string name="privacy_text">Domyślnie Twoje zapytania będą kierowane do
-    <a href="https://developers.google.com/speed/public-dns/">publicznego serwera DNS Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Polityka prywatności</a>).
-    Możesz też wybrać <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Polityka prywatności</a>)
-    lub inną usługę DoH (DNS over HTTPS).</string>
-  <string name="accept">Rozpocznij</string>
   <string name="drawer_open">Otwórz panel nawigacji</string>
   <string name="drawer_close">Zamknij panel nawigacji</string>
   <string name="home">Strona główna</string>
   <string name="settings">Ustawienia</string>
-  <string name="feedback">Prześlij opinię</string>
   <string name="support">Pomoc</string>
   <string name="privacy_link">Polityka prywatności</string>
   <string name="tos_link">Warunki świadczenia usług</string>
   <string name="source_code">Kod źródłowy</string>
-  <string name="short_credits_text">Intra to eksperymentalny projekt open source autorstwa <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Aplikacja Intra została stworzona przez <a href="https://jigsaw.google.com">Jigsaw</a>. Lokalizacja adresu IP jest ustalana
     na podstawie danych ze strony DB-IP.com.</string>
   <string name="indicator_on">Włączono</string>
@@ -37,25 +25,37 @@
   <string name="status_protected">Chronione</string>
   <string name="explanation_protected">Połączenie jest chronione przed atakami DNS.</string>
   <string name="status_upgraded">Podatne</string>
-  <string name="explanation_upgraded">Połączenie jest obecnie chronione ustawieniem Prywatny DNS Androida, ale atakujący może je wyłączyć
-    lub obejść.</string>
+  <string name="explanation_upgraded">Połączenie jest obecnie chronione ustawieniem Prywatny DNS Androida, ale atakujący może je wyłączyć lub obejść.</string>
   <string name="status_strict">Chronione przez Androida</string>
-  <string name="explanation_strict">Aplikacja Intra wykryła, że jest włączone ustawienie Prywatny DNS Androida. Oznacza to,
-    że zapytania DNS są już chronione i nie ma potrzeby włączać aplikacji Intra.</string>
+  <string name="explanation_strict">Aplikacja Intra wykryła, że jest włączone ustawienie Prywatny DNS Androida. Oznacza to, że zapytania DNS są już chronione i nie ma potrzeby włączać aplikacji Intra.</string>
   <string name="status_starting">Uruchamiam…</string>
   <string name="explanation_starting">Daj nam chwilę. Intra nawiązuje połączenie z serwerem.</string>
   <string name="status_waiting">Czekam…</string>
   <string name="explanation_offline">Twoje urządzenie jest w trybie offline. Intra czeka na połączenie z internetem.</string>
-  <string name="explanation_vpn">Aplikacja Intra wykryła na tym urządzeniu inny VPN. Jeśli ją włączysz, VPN zostanie wyłączony.
-    Intra nie jest tak bezpieczna jak zaufana sieć VPN.</string>
+  <string name="explanation_vpn">Aplikacja Intra wykryła na tym urządzeniu inny VPN. Jeśli ją włączysz, VPN zostanie wyłączony. Intra nie jest tak bezpieczna jak zaufana sieć VPN.</string>
   <string name="explanation_failing">Ostrzeżenie: zapytania nie są realizowane. Wybierz inny serwer i ponownie uruchom aplikację Intra.</string>
   <string name="system_details">Szczegółowe informacje o systemie</string>
   <string name="num_requests">Zapytania od początku używania</string>
+  <string name="num_requests_headline">Zapytania DNS są wykonywane, gdy urządzenie sprawdza adres IP odpowiadający nazwie domenowej</string>
+  <string name="num_requests_body">Ta wartość to łączna liczba zapytań DNS wykonanych przez Twoje urządzenie, gdy aplikacja Intra była aktywna. Intra szyfruje te zapytania i wysyła je do zaufanego serwera, by mieć pewność, że uzyskiwane odpowiedzi są autentyczne.</string>
   <string name="queries_per_minute">Ostatnie zapytania</string>
+  <string name="queries_per_minute_headline">Zapytania DNS są wykonywane na początku każdego połączenia</string>
+  <string name="queries_per_minute_body">Ta wartość to liczba zapytań DNS wykonanych przez Twoje urządzenie w ostatniej minucie. Załadowanie skomplikowanej strony internetowej wymaga czasem ponad stu zapytań DNS.</string>
   <string name="transport_label">Szyfrowany protokół</string>
-  <string name="insecure_transport_label">Nieszyfrowany protokół</string>
+  <string name="transport_headline">Szyfrowanie chroni Twoje zapytania przed podsłuchaniem</string>
+  <string name="transport_body">Gdy używasz aplikacji Intra, Twoje zapytania DNS są szyfrowane, dzięki czemu tylko Ty i Twój serwer DNS znacie ich treść. Intra do szyfrowania używa protokołu DNS przez HTTPS.</string>
+  <string name="default_transport_label">Domyślny protokół transportowy</string>
+  <string name="insecure_transport">brak szyfrowania</string>
+  <string name="insecure_transport_headline">Podstawowy protokół DNS nie stosuje szyfrowania</string>
+  <string name="insecure_transport_body">Większość urządzeń i sieci używa podstawowego protokołu DNS, który nie stosuje szyfrowania, przez co Twoje zapytania DNS mogą zostać podsłuchane lub zmodyfikowane przez kogoś w sieci. Niektóre nowe urządzenia obsługują protokół DNS przez TLS, który szyfruje zapytania, ale nie zapewnia ochrony przed złośliwym serwerem.</string>
   <string name="server_label">Bezpieczny serwer DNS</string>
-  <string name="insecure_server_label">Serwer DNS operatora sieci</string>
+  <string name="server_headline">Zasługujesz na zaufany serwer DNS</string>
+  <string name="server_body">W tym polu jest podana nazwa bezpiecznego serwera DNS, którego używasz. W menu Ustawienia możesz wybrać inny serwer.</string>
+  <string name="default_server_label">Obecny serwer DNS</string>
+  <string name="insecure_server_headline">Możesz wybrać własny serwer DNS</string>
+  <string name="insecure_server_body">Gdy Intra jest wyłączona, większość urządzeń korzysta domyślnie z serwera DNS wybranego przez operatora sieci. W tym polu widać adres IP serwera DNS, którego obecnie używa Twoje urządzenie. Preferowany serwer możesz łatwo wybrać w aplikacji Intra lub na Androidzie P.</string>
+  <string name="strict_mode_server_headline">Używasz bezpiecznego serwera</string>
+  <string name="strict_mode_server_body">W tym polu widać nazwę serwera DNS skonfigurowanego na Androidzie jako Prywatny DNS.  Gdy Intra jest wyłączona, Twoje aplikacje powinny przesyłać zapytania DNS do tego serwera.</string>
   <string name="unknown_server">(nieznany serwer)</string>
   <string name="show_history">Pokaż ostatnie zapytania</string>
   <string name="query_label">Zapytanie</string>
@@ -72,12 +72,6 @@
     jest niezgodna z Intra, możesz dodać ją tutaj.</string>
   <string name="excluded_apps_title">Wybierz aplikacje do wykluczenia w Intra</string>
   <string name="old_android">Ta funkcja jest niedostępna w tej wersji Androida.</string>
-  <string name="before_feedback">Pomóż nam ulepszać aplikację Intra. Jesteśmy na wczesnym etapie jej tworzenia i potrzebujemy Twojej pomocy.
-    Daj znać, co działa, a co nie. Dziękujemy!</string>
-  <string name="feedback_hint">Twoja opinia</string>
-  <string name="after_feedback">Ta informacja zostanie wysłana do zespołu aplikacji Intra. Nie umieszczaj w niej żadnych
-    danych osobowych.</string>
-  <string name="submit_feedback">Wyślij</string>
   <string name="notification_title">Ochrona DNS jest aktywna</string>
   <string name="notification_content">Kliknij, by zmienić ustawienia ochrony DNS</string>
   <string name="channel_name">Powiadomienie o aktywnej ochronie DNS</string>

--- a/Android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/Android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Um caminho mais seguro para uma Internet mais aberta</string>
-  <string name="intro_benefit_body">Quando você usa a Internet, o dispositivo precisa procurar endereços em uma lista de contatos da Internet. Às vezes, sua conexão informa o endereço errado a você.</string>
-  <string name="intro_manipulation_headline">Proteção contra endereços errados</string>
-  <string name="intro_manipulation_body">O Intra criptografa sua conexão DNS para evitar que você receba endereços errados que não levam a lugar nenhum (manipulação de DNS).</string>
-  <string name="intro_details_headline">O Intra precisa monitorar o tráfego de rede para ativar a proteção</string>
-  <string name="intro_details_body">Para começar, toque em \"OK\" ao ver a solicitação de conexão. Por padrão, suas consultas serão roteadas para o DNS público do Google (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidade</a>). Você pode escolher outro serviço nas configurações do app.</string>
+  <string name="intro_benefit_headline">Acesso melhor à Internet</string>
+  <string name="intro_benefit_body">O Intra protege contra a manipulação de DNS, um ataque cibernético que bloqueia o acesso a sites de notícias, plataformas de mídia social e apps de mensagens.\n\nNo entanto, o Intra não impede outros ataques e técnicas de bloqueio mais complexos.</string>
+  <string name="intro_manipulation_headline">Proteção contra manipulação de DNS</string>
+  <string name="intro_manipulation_body">O Intra protege sua conexão com o Sistema de Nome de Domínio (DNS), que informa os endereços necessários para visitar um site ou abrir um app.\n\nComo o Intra usa a criptografia para impedir a manipulação dos resultados, você acessa a Internet com segurança.</string>
+  <string name="intro_details_headline">Só mais uma informação…</string>
+  <string name="intro_details_body">Toque em \"OK\" para permitir que o Intra proteja suas solicitações DNS. Por padrão, elas serão roteadas para o DNS público do Google (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidade</a>). Você pode escolher outro serviço nas configurações do app.</string>
   <string name="intro_back">voltar</string>
   <string name="intro_next">próxima</string>
   <string name="intro_accept">aceitar</string>
-  <string name="about_headline">DNS confiável e seguro</string>
-  <string name="about_text">O Intra roteia suas consultas de DNS por uma conexão HTTPS segura para protegê-las. Isso reduz o risco de você ser direcionado ao site errado ou ter a navegação bloqueada ou observada.</string>
-  <string name="privacy_text">Por padrão, suas consultas serão encaminhadas para o
-    <a href="https://developers.google.com/speed/public-dns/">DNS público do Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Política de Privacidade</a>).
-    Você também pode usar o <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Política de Privacidade</a>)
-    ou outro serviço DNS por HTTPS.</string>
-  <string name="accept">Primeiros passos</string>
   <string name="drawer_open">Abrir a gaveta de navegação</string>
   <string name="drawer_close">Fechar a gaveta de navegação</string>
   <string name="home">Página inicial</string>
   <string name="settings">Configurações</string>
-  <string name="feedback">Enviar feedback</string>
   <string name="support">Suporte</string>
   <string name="privacy_link">Política de Privacidade</string>
   <string name="tos_link">Termos de Serviço</string>
   <string name="source_code">Código-fonte</string>
-  <string name="short_credits_text">O Intra é um projeto experimental de código aberto da <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">O Intra foi criado pela <a href="https://jigsaw.google.com">Jigsaw</a>. Os endereços IP são baseados em dados do site DB-IP.com.</string>
   <string name="indicator_on">Ativado</string>
   <string name="indicator_off">Desativado</string>
@@ -47,11 +36,26 @@ Uma VPN confiável é mais segura que o Intra.</string>
   <string name="explanation_failing">Atenção: houve falha nas consultas. Escolha outro servidor e reinicie o Intra.</string>
   <string name="system_details">Detalhes do sistema</string>
   <string name="num_requests">Todas as consultas</string>
+  <string name="num_requests_headline">As consultas DNS ocorrem quando o dispositivo pesquisa o endereço IP de um nome de domínio</string>
+  <string name="num_requests_body">Este valor mostra o número total de consultas DNS feitas pelo dispositivo enquanto o Intra estava ativo. O Intra criptografa essas consultas e as envia para um servidor confiável, garantindo que você receba resultados autênticos.</string>
   <string name="queries_per_minute">Consultas recentes</string>
+  <string name="queries_per_minute_headline">As consultas DNS ocorrem no início de cada conexão</string>
+  <string name="queries_per_minute_body">Este valor mostra o número de consultas DNS feitas pelo dispositivo no último minuto. Podem ser necessárias mais de cem consultas DNS para carregar uma página da Web complexa.</string>
   <string name="transport_label">Transporte criptografado</string>
-  <string name="insecure_transport_label">Transporte não criptografado</string>
+  <string name="transport_headline">A criptografia protege suas consultas dos olhares curiosos</string>
+  <string name="transport_body">No Intra, suas consultas DNS são criptografadas, por isso só você e o servidor as veem. Para criptografá-las, o Intra usa o protocolo DNS por HTTPS.</string>
+  <string name="default_transport_label">Transporte padrão</string>
+  <string name="insecure_transport">não criptografado</string>
+  <string name="insecure_transport_headline">O DNS básico não é criptografado</string>
+  <string name="insecure_transport_body">A maioria dos dispositivos e redes usa o DNS básico, que não é criptografado, por isso suas consultas DNS podem ser observadas ou modificadas por qualquer pessoa na rede. Alguns dispositivos novos são compatíveis com o DNS por TLS, um protocolo que criptografa as consultas, mas não as protege quando o servidor é mal-intencionado.</string>
   <string name="server_label">Servidor DNS seguro</string>
-  <string name="insecure_server_label">Servidor DNS fornecido pela rede</string>
+  <string name="server_headline">Você merece usar um servidor DNS confiável</string>
+  <string name="server_body">Este campo mostra o nome do servidor DNS seguro em uso. Você também pode mudar de servidor no menu \"Configurações\".</string>
+  <string name="default_server_label">Servidor DNS atual</string>
+  <string name="insecure_server_headline">Escolha seu próprio servidor DNS</string>
+  <string name="insecure_server_body">Depois que o Intra é desativado, a maioria dos dispositivos é pré-configurada para usar o servidor DNS escolhido pela sua operadora de rede. Este campo mostra o endereço IP do servidor DNS que o dispositivo está usando no momento. Com o Intra ou o Android P, você seleciona com facilidade o servidor que preferir.</string>
+  <string name="strict_mode_server_headline">Você selecionou um servidor seguro</string>
+  <string name="strict_mode_server_body">Este campo mostra o nome do servidor DNS que você definiu na configuração de DNS particular do Android.  Depois que o Intra é desativado, os apps enviam consultas DNS para esse servidor.</string>
   <string name="unknown_server">(servidor desconhecido)</string>
   <string name="show_history">Mostrar consultas recentes</string>
   <string name="query_label">Consulta</string>
@@ -67,11 +71,6 @@ Uma VPN confiável é mais segura que o Intra.</string>
   <string name="excluded_apps_summary">As consultas DNS dos apps selecionados não passarão pelo Intra. Se um app for incompatível com o Intra, você poderá adicioná-lo aqui.</string>
   <string name="excluded_apps_title">Marcar apps excluídos do Intra</string>
   <string name="old_android">Esta funcionalidade não está disponível na sua versão do Android.</string>
-  <string name="before_feedback">Ajude a aprimorar o Intra. O produto está na fase inicial de desenvolvimento, e precisamos do seu feedback para melhorá-lo.
-Diga o que está dando certo e o que podemos mudar. Agradecemos sua colaboração.</string>
-  <string name="feedback_hint">Seu feedback</string>
-  <string name="after_feedback">Estes comentários serão enviados à equipe do Intra. Não inclua informações pessoais no feedback.</string>
-  <string name="submit_feedback">Enviar</string>
   <string name="notification_title">A proteção do DNS está ativa</string>
   <string name="notification_content">Toque para alterar a configuração da proteção do DNS</string>
   <string name="channel_name">Notificação de proteção do DNS ativa</string>

--- a/Android/app/src/main/res/values-ru/strings.xml
+++ b/Android/app/src/main/res/values-ru/strings.xml
@@ -1,27 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Безопасный доступ к свободному Интернету</string>
-  <string name="intro_benefit_body">Когда вы хотите открыть какой-либо сайт, ваше устройство отправляет запрос на поиск его IP-адреса. Иногда в ответ на такой запрос может прийти ложный адрес.</string>
-  <string name="intro_manipulation_headline">Защита от ложных веб-адресов</string>
-  <string name="intro_manipulation_body">Intra защитит вас от перехода на сайты с ложными IP-адресами, которые ведут в тупик вследствие перехвата DNS, благодаря шифрованию DNS-соединения.</string>
-  <string name="intro_details_headline">Для активации защиты приложению Intra необходим доступ к данным сетевого трафика</string>
-  <string name="intro_details_body">Нажмите ОК, когда появится запрос на подключение. По умолчанию ваши запросы будут направляться на Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Политика конфиденциальности</a>). В настройках приложения можно выбрать другой сервис.</string>
+  <string name="intro_benefit_headline">Свободный доступ в Интернет</string>
+  <string name="intro_benefit_body">Приложение Intra защищает вас от перехвата DNS-запросов – кибератаки, в результате которой блокируется доступ к новостным сайтам, социальным сетям и мессенджерам.\n\nОбратите внимание, что существуют более сложные техники и атаки, против которых Intra не поможет.</string>
+  <string name="intro_manipulation_headline">Защита от перехвата DNS-запросов</string>
+  <string name="intro_manipulation_body">Intra защищает ваше подключение к системе доменных имен (DNS), которая предоставляет точные адреса для посещения сайтов или запуска приложений.\n\nБлагодаря шифрованию предотвращается перехват и подмена DNS-запросов. Это обеспечивает безопасный доступ к Интернету.</string>
+  <string name="intro_details_headline">И последний важный момент…</string>
+  <string name="intro_details_body">Чтобы включить защиту DNS-запросов, нажмите \"ОК\". По умолчанию они будут направляться на сервер Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Политика конфиденциальности</a>). В настройках приложения можно выбрать другой сервис.</string>
   <string name="intro_back">назад</string>
   <string name="intro_next">далее</string>
   <string name="intro_accept">принять</string>
-  <string name="about_headline">Безопасные DNS-запросы</string>
-  <string name="about_text">Приложение Intra обеспечивает безопасность DNS-запросов, отправляя их через защищенное HTTPS-соединение. Это снижает вероятность перенаправления на неверный сайт, отслеживания ваших действий и блокировки доступа к Интернету.</string>
-  <string name="privacy_text">По умолчанию ваши запросы будут направляться на сервер <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a> (<a href="https://developers.google.com/speed/public-dns/privacy">Политика конфиденциальности</a>). Также вы можете воспользоваться сервисом компании <a href="https://cloudflare-dns.com">Cloudflare</a> (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Политика конфиденциальности</a>) или любым другим сервисом, использующим протокол DNS поверх HTTPS.</string>
-  <string name="accept">Начать</string>
   <string name="drawer_open">Открыть панель навигации</string>
   <string name="drawer_close">Закрыть панель навигации</string>
   <string name="home">Главный экран</string>
   <string name="settings">Настройки</string>
-  <string name="feedback">Отправить отзыв</string>
   <string name="support">Справка и поддержка</string>
   <string name="privacy_link">Политика конфиденциальности</string>
   <string name="tos_link">Условия использования</string>
   <string name="source_code">Исходный код</string>
-  <string name="short_credits_text">Intra – это экспериментальное приложение с открытым исходным кодом, разработанное компанией <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Приложение Intra разработано компанией <a href="https://jigsaw.google.com">Jigsaw</a>. Местонахождение IP-адресов определяется на основе данных с сайта DB-IP.com.</string>
   <string name="indicator_on">Включено</string>
   <string name="indicator_off">Отключено</string>
@@ -41,11 +35,26 @@
   <string name="explanation_failing">Не удается отправить запросы. Попробуйте выбрать другой сервер и перезапустить Intra.</string>
   <string name="system_details">Сведения о системе</string>
   <string name="num_requests">Всего запросов</string>
+  <string name="num_requests_headline">Ваше устройство отправляет DNS-запрос, чтобы получить IP-адрес для доменного имени</string>
+  <string name="num_requests_body">Это число показывает общее количество DNS-запросов, которые ваше устройство отправило за время использования Intra. Запросы шифруются и отправляются на надежный сервер, чтобы никто не мог подменить данные.</string>
   <string name="queries_per_minute">Недавние запросы</string>
+  <string name="queries_per_minute_headline">DNS-запросы отправляются в начале каждого соединения</string>
+  <string name="queries_per_minute_body">Это число показывает количество DNS-запросов, которые ваше устройство отправило за последнюю минуту. Для загрузки сложной веб-страницы может понадобиться больше 100 DNS-запросов.</string>
   <string name="transport_label">Зашифрованная передача данных</string>
-  <string name="insecure_transport_label">Незашифрованная передача данных</string>
+  <string name="transport_headline">Шифрование обеспечивает конфиденциальность запросов</string>
+  <string name="transport_body">Приложение Intra шифрует DNS-запросы так, что они доступны только вам и вашему DNS-серверу. Для шифрования используется протокол DNS поверх HTTPS.</string>
+  <string name="default_transport_label">Протокол по умолчанию</string>
+  <string name="insecure_transport">без шифрования</string>
+  <string name="insecure_transport_headline">Базовая DNS не шифруется</string>
+  <string name="insecure_transport_body">Большинство устройств и сетей используют базовую DNS, которая никак не шифруется. Кто угодно может перехватить и изменить ваши DNS-запросы. Некоторые новые устройства поддерживают протокол DNS поверх TLS, который шифрует запросы, но не может защитить вас от угроз со стороны сервера злоумышленников.</string>
   <string name="server_label">Защищенный DNS-сервер</string>
-  <string name="insecure_server_label">DNS-сервер, предоставленный сетью</string>
+  <string name="server_headline">Используйте надежные DNS-серверы</string>
+  <string name="server_body">В этом поле указано название защищенного DNS-сервера, который вы используете. В меню \"Настройки\" можно выбрать другой сервер.</string>
+  <string name="default_server_label">Текущий DNS-сервер</string>
+  <string name="insecure_server_headline">Вы можете выбрать собственный DNS-сервер</string>
+  <string name="insecure_server_body">Когда приложение Intra отключено, на большинстве устройств действуют предварительно заданные настройки, согласно которым следует использовать DNS-сервер, выбранный оператором сети. В этом поле указан IP-адрес DNS-сервера, используемого устройством в настоящий момент. Используя приложение Intra или Android P, вы можете выбирать сервер по своему усмотрению.</string>
+  <string name="strict_mode_server_headline">Вы выбрали защищенный сервер</string>
+  <string name="strict_mode_server_body">В этом поле указано название DNS-сервера, настроенного вами в Android (параметр \"Персональный DNS\").  Когда приложение Intra отключено, ваши приложения должны отправлять DNS-запросы на этот сервер.</string>
   <string name="unknown_server">(неизвестный сервер)</string>
   <string name="show_history">Показывать недавние запросы</string>
   <string name="query_label">Запрос</string>
@@ -61,10 +70,6 @@
   <string name="excluded_apps_summary">DNS-запросы от выбранных приложений не будут отправляться через Intra. Если приложение несовместимо с Intra, вы можете добавить его в список исключенных.</string>
   <string name="excluded_apps_title">Выберите приложения, которые хотите исключить из Intra</string>
   <string name="old_android">Эти функции недоступны в вашей версии Android.</string>
-  <string name="before_feedback">Приложение Intra находится на ранней стадии разработки, поэтому нам нужна ваша помощь, чтобы сделать его лучше. Сообщите нам, какие компоненты работают корректно, а какие нет.</string>
-  <string name="feedback_hint">Ваш отзыв</string>
-  <string name="after_feedback">Отзыв будет отправлен команде Intra. Не указывайте в нем личную информацию.</string>
-  <string name="submit_feedback">Отправить</string>
   <string name="notification_title">Защита DNS-запросов включена</string>
   <string name="notification_content">Нажмите, чтобы включить или выключить защиту DNS-запросов</string>
   <string name="channel_name">Уведомление об активном статусе защиты DNS-запросов</string>

--- a/Android/app/src/main/res/values-sw/strings.xml
+++ b/Android/app/src/main/res/values-sw/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Njia salama zaidi ya kukuza intaneti wazi</string>
-  <string name="intro_benefit_body">Unapotumia intaneti, kifaa chako kinahitaji kutafuta anwani katika orodha ya anwani za intaneti. Wakati mwingine muunganisho wako unaweza kukupa anwani isiyo sahihi.</string>
-  <string name="intro_manipulation_headline">Ulinzi dhidi ya anwani zisizo sahihi</string>
-  <string name="intro_manipulation_body">Intra hukulinda dhidi ya kupata anwani mbaya zisizoelekea kokote (ughushi wa DNS) kwa kusimba muunganisho wako wa DNS kwa njia fiche.</string>
-  <string name="intro_details_headline">Intra inahitaji kufuatilia trafiki ya mtandao ili iweze kuweka ulinzi</string>
-  <string name="intro_details_body">Gusa \"Sawa\" ukiona ombi la kuunganisha ili uanze. Kwa chaguomsingi, hoja zako zitaelekezwa kwenye DNS ya Umma ya Google (<a href="https://developers.google.com/speed/public-dns/privacy">Sera ya Faragha</a>). Unaweza kuchagua kutumia huduma nyingine katika mipangilio ya programu.</string>
+  <string name="intro_benefit_headline">Uwazi zaidi katika ufikiaji wa intaneti</string>
+  <string name="intro_benefit_body">Intra hukulinda dhidi ya ughushi wa DNS, uvamizi wa kimtandao unaotumiwa kuzuia ufikiaji wa tovuti za habari, mitandao ya kijamii na programu za kutuma na kupokea ujumbe.\n\nIjapokuwa Intra hukulinda dhidi ya ughushi wa DNS, kuna mbinu zingine changamano za uzuiaji na uvamizi ambazo Intra haiwezi kukulinda dhidi yake.</string>
+  <string name="intro_manipulation_headline">Ulinzi dhidi ya ughushi wa DNS</string>
+  <string name="intro_manipulation_body">Intra hulinda muunganisho wako kwenye Mfumo wa Majina ya Vikoa (DNS), unaokupa anwani mahususi unazohitaji ili utembelee tovuti au programu.\n\nIntra hutumia usimbaji fiche kuhakikisha kuwa matokeo hayawezi kubadilishwa, hivyo kukuwezesha kufikia intaneti kwa njia salama.</string>
+  <string name="intro_details_headline">Jambo moja la mwisho…</string>
+  <string name="intro_details_body">Gusa Sawa ili uruhusu Intra ilinde maombi yako ya DNS. Kwa chaguomsingi, maombi yako yataelekezwa kwenye DNS ya Umma ya Google (<a href="https://developers.google.com/speed/public-dns/privacy">Sera ya Faragha</a>). Unaweza kuchagua kutumia huduma nyingine katika mipangilio ya programu.</string>
   <string name="intro_back">rudi nyuma</string>
   <string name="intro_next">endelea</string>
   <string name="intro_accept">kubali</string>
-  <string name="about_headline">Mfumo wa DNS ulio salama na wa kuaminika</string>
-  <string name="about_text">Intra hulinda maombi yako ya DNS kwa kuyapitisha kwenye muunganisho salama wa HTTPS. Hatua hii hupunguza
-    uwezekano wa ombi lako kutumwa kwa tovuti isiyo sahihi au shughuli zako za kuvinjari kuzuiwa au kufuatiliwa.</string>
-  <string name="privacy_text">Kwa chaguomsingi, hoja zako zitaelekezwa kwenye
-    <a href="https://developers.google.com/speed/public-dns/">DNS ya Umma ya Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Sera ya Faragha</a>).
-    Unaweza pia kutumia <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Sera ya Faragha</a>)
-    au huduma yoyote nyingine ya DNS-inayopitia kwa-HTTPS.</string>
-  <string name="accept">Anza Kuitumia</string>
   <string name="drawer_open">Fungua menyu ya kusogeza</string>
   <string name="drawer_close">Funga menyu ya kusogeza</string>
   <string name="home">Mwanzo</string>
   <string name="settings">Mipangilio</string>
-  <string name="feedback">Tuma Maoni</string>
   <string name="support">Usaidizi</string>
   <string name="privacy_link">Sera ya Faragha</string>
   <string name="tos_link">Sheria na Masharti</string>
   <string name="source_code">Msimbo wa Asili</string>
-  <string name="short_credits_text">Intra ni mradi wa majaribio ya programu huria unaoendeshwa na <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra imetengenezwa na <a href="https://jigsaw.google.com">Jigsaw</a>. Maelezo ya maeneo ya IP yanatokana na data
     kutoka DB-IP.com.</string>
   <string name="indicator_on">Imewashwa</string>
@@ -51,11 +39,33 @@
   <string name="explanation_failing">Onyo: Kuna matatizo ya kuchakata hoja. Unaweza kuchagua seva tofauti na uzime Intra kisha uiwashe tena.</string>
   <string name="system_details">Maelezo ya mfumo</string>
   <string name="num_requests">Maombi yote</string>
+  <string name="num_requests_headline">Hoja za DNS hutokea kifaa chako kinapotafuta anwani ya IP ya jina la kikoa</string>
+  <string name="num_requests_body">Thamani hii inaonyesha idadi kamili ya hoja za DNS ambazo kifaa chako kimetekeleza wakati intra
+    ilikuwa inatumika. Intra husimba hoja hizi kwa njia fiche na kuzituma kwenye seva ya kuaminika ili kuhakikisha kuwa
+    unapata matokeo halisi.</string>
   <string name="queries_per_minute">Maombi ya hivi punde</string>
+  <string name="queries_per_minute_headline">Hoja za DNS hutokea mwanzoni mwa kila muunganisho</string>
+  <string name="queries_per_minute_body">Thamani hii inaonyesha idadi ya hoja za DNS ambazo kifaa chako kimetekeleza katika dakika ya mwisho.
+    Unaweza kuhitaji zaidi ya hoja mia moja za DNS kupakia ukurasa changamano wa wavuti.</string>
   <string name="transport_label">Uhamishaji data uliosimbwa kwa njia fiche</string>
-  <string name="insecure_transport_label">Uhamishaji data usiosimbwa kwa njia fiche</string>
+  <string name="transport_headline">Usimbaji fiche hulinda hoja zako dhidi ya macho ya nje</string>
+  <string name="transport_body">Unapotumia Intra, hoja zako za DNS husimbwa kwa njia fiche, hivi kwamba ni wewe na seva yako ya DNS pekee mnaoweza kuona
+    hoja za DNS unazotuma. Intra hutekeleza DNS kupitia kwa itifaki ya HTTPS ili isimbwe kwa njia fiche.</string>
+  <string name="default_transport_label">Usafirishaji chaguomsingi</string>
+  <string name="insecure_transport">haijasimbwa kwa njia fiche</string>
+  <string name="insecure_transport_headline">DNS ya msingi haijasimbwa kwa njia fiche</string>
+  <string name="insecure_transport_body">Vifaa na mitandao mingi hutumia DNS ya msingi, ambayo haijasimbwa kwa njia fiche, kwa hivyo hoja zako za DNS zinaweza
+    kuangaliwa au kubadilishwa na yeyote aliye kwenye mtandao.  Baadhi ya vifaa hutumia DNS inayopitia kwa TLS, ambayo
+    husimba hoja zako kwa njia fiche lakini haiwezi kukulinda iwapo seva ni mbaya.</string>
   <string name="server_label">Seva salama ya DNS</string>
-  <string name="insecure_server_label">Seva ya DNS iliyotolewa na mtandao</string>
+  <string name="server_headline">Unastahili kutumia seva ya DNS inayoaminika</string>
+  <string name="server_body">Sehemu hii inaonyesha jina la seva salama ya DNS unayotumia.  Unaweza pia kubadilisha utumie
+    seva tofauti katika menyu ya Mipangilio.</string>
+  <string name="default_server_label">Seva ya sasa ya DNS</string>
+  <string name="insecure_server_headline">Unaweza kuchagua seva yako ya DNS</string>
+  <string name="insecure_server_body">Intra ikizimwa, vifaa vingi huwekewa mipangilio awali ili vitumie seva  ay DNS itakayochaguliwa na mtoa huduma wako wa mtandao. Sehemu hii huonyesha anwani ya IP ya seva ya DNS ambayo kifaa chako kinatumia kwa sasa. Ukiwa na Intra au Android P, unaweza kuchagua seva unayoipenda kwa urahisi.</string>
+  <string name="strict_mode_server_headline">Umechagua seva salama</string>
+  <string name="strict_mode_server_body">Sehemu hii inaonyesha jina la seva ya DNS uliyowekea mipangilio katika mipangilio ya Android ya DNS ya Faragha.  Intra ikizimwa, programu zako zinapaswa kutuma hoja za DNS kwa seva hii.</string>
   <string name="unknown_server">(seva isiyojulikana)</string>
   <string name="show_history">Onyesha maombi ya hivi majuzi</string>
   <string name="query_label">Ombi</string>
@@ -70,14 +80,8 @@
   <string name="excluded_apps">Programu zilizotengwa</string>
   <string name="excluded_apps_summary">Hoja za DNS kutoka kwenye programu zozote zilizochaguliwa hazitapitia kwenye Intra.  Ikiwa programu inaonekana
     kutooana na Intra, unaweza kuiongeza hapa.</string>
-  <string name="excluded_apps_title">Weka alama kwenye programu utakazotenga na Intra</string>
+  <string name="excluded_apps_title">Tia alama kwenye programu utakazotenga na Intra</string>
   <string name="old_android">Utendaji huu haupatikani kwenye toleo lako la Android.</string>
-  <string name="before_feedback">Tusaidie kuboresha Intra! Intra ni huduma changa na tunahitaji usaidizi wako kuiboresha.
-    Tueleze uzuri na upungufu wake.  Asante!</string>
-  <string name="feedback_hint">Maoni yako</string>
-  <string name="after_feedback">Maelezo haya yatatumwa kwa timu ya Intra.  Tafadhali usiweke taarifa yoyote ya binafsi
-    katika maoni yako.</string>
-  <string name="submit_feedback">Tuma</string>
   <string name="notification_title">Kipengle cha kulinda DNS kimewashwa</string>
   <string name="notification_content">Gusa ili ubadilishe mipangilio ya ulinzi wa DNS</string>
   <string name="channel_name">Arifa ya Kuonyesha Kipengele cha Kulinda DNS Kimewashwa</string>

--- a/Android/app/src/main/res/values-th/strings.xml
+++ b/Android/app/src/main/res/values-th/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">ใช้อินเทอร์เน็ตแบบเปิดบนเส้นทางที่ปลอดภัยมากขึ้น</string>
-  <string name="intro_benefit_body">เมื่อใช้อินเทอร์เน็ต อุปกรณ์ของคุณต้องค้นหาที่อยู่ในรายชื่อติดต่อทางอินเทอร์เน็ต แต่บางครั้งการเชื่อมต่อก็อาจทำให้ระบุที่อยู่ผิดได้</string>
-  <string name="intro_manipulation_headline">การป้องกันที่อยู่ผิด</string>
-  <string name="intro_manipulation_body">Intra ช่วยปกป้องคุณจากการได้รับที่อยู่ที่ไม่ถูกต้องซึ่งนำไปสู่ทางตัน (การเปลี่ยนเส้นทาง DNS) โดยการเข้ารหัสการเชื่อมต่อ DNS</string>
-  <string name="intro_details_headline">Intra ต้องตรวจสอบการจราจรของข้อมูลในเครือข่ายเพื่อทำการปกป้อง</string>
-  <string name="intro_details_body">แตะ \"ตกลง\" เมื่อเห็นคำขอการเชื่อมต่อเพื่อเริ่มต้นใช้งาน โดยค่าเริ่มต้น คำขอของคุณจะกำหนดเส้นทางไปที่ DNS สาธารณะของ Google (<a href="https://developers.google.com/speed/public-dns/privacy">นโยบายความเป็นส่วนตัว</a>) นอกจากนี้คุณยังเลือกใช้บริการอื่นในการตั้งค่าแอปได้อีกด้วย</string>
+  <string name="intro_benefit_headline">เข้าถึงอินเทอร์เน็ตได้อย่างอิสระมากยิ่งขึ้น</string>
+  <string name="intro_benefit_body">Intra จะช่วยป้องกันการควบคุม DNS ซึ่งเป็นการโจมตีทางไซเบอร์ที่บล็อกการเข้าถึงเว็บไซต์ข่าวสาร แพลตฟอร์มโซเชียลมีเดีย และแอปรับส่งข้อความ\n\nแม้ว่า Intra จะป้องกันไม่ให้มีการควบคุม DNS แต่ก็มีเทคนิคการบล็อกที่ซับซ้อนอีกมากมาย รวมทั้งการโจมตีอื่นๆ ที่ Intra ยังป้องกันไม่ได้</string>
+  <string name="intro_manipulation_headline">ป้องกันการควบคุม DNS</string>
+  <string name="intro_manipulation_body">Intra จะช่วยปกป้องการเชื่อมต่อไปยังระบบชื่อโดเมน (DNS) ซึ่งจะมอบข้อมูลที่อยู่ที่ถูกต้องให้คุณในการเข้าชมเว็บไซต์หรือเปิดใช้แอป\n\nIntra ใช้การเข้ารหัสลับเพื่อป้องกันไม่ให้มีการควบคุม DNS จึงช่วยให้คุณเข้าถึงอินเทอร์เน็ตได้อย่างปลอดภัย</string>
+  <string name="intro_details_headline">สิ่งสุดท้าย…</string>
+  <string name="intro_details_body">แตะ \"ตกลง\" เพื่ออนุญาตให้ Intra ปกป้องคำขอ DNS ของคุณ โดยค่าเริ่มต้น คำขอจะส่งไปยัง DNS สาธารณะของ Google (<a href="https://developers.google.com/speed/public-dns/privacy">นโยบายความเป็นส่วนตัว</a>) นอกจากนี้คุณยังเลือกใช้บริการอื่นในการตั้งค่าแอปได้</string>
   <string name="intro_back">ย้อนกลับ</string>
   <string name="intro_next">ถัดไป</string>
   <string name="intro_accept">ยอมรับ</string>
-  <string name="about_headline">DNS ที่ไว้ใจได้และปลอดภัย</string>
-  <string name="about_text">Intra ป้องกันการค้นหา DNS โดยการกำหนดเส้นทางการเชื่อมต่อ HTTP ที่ปลอดภัย การดำเนินการนี้จะช่วยลดโอกาสที่คุณจะเข้าถึงเว็บไซต์ที่ไม่ถูกต้อง หรือการท่องเว็บที่ถูกบล็อกหรือมีปัญหา</string>
-  <string name="privacy_text">โดยค่าเริ่มต้น คำขอของคุณจะกำหนดเส้นทางไปที่
-    <a href="https://developers.google.com/speed/public-dns/">DNS สาธารณะของ Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">นโยบายความเป็นส่วนตัว</a>)
-    นอกจากนี้ยังเลือกใช้ <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">นโยบายความเป็นส่วนตัว</a>)
-    หรือบริการ DNS ผ่านโปรโตคอล HTTPS อื่นๆ ได้อีกด้วย</string>
-  <string name="accept">เริ่มต้นใช้งาน</string>
   <string name="drawer_open">เปิดลิ้นชักการนำทาง</string>
   <string name="drawer_close">ปิดลิ้นชักการนำทาง</string>
   <string name="home">หน้าแรก</string>
   <string name="settings">การตั้งค่า</string>
-  <string name="feedback">ส่งความคิดเห็น</string>
   <string name="support">การสนับสนุน</string>
   <string name="privacy_link">นโยบายความเป็นส่วนตัว</string>
   <string name="tos_link">ข้อกำหนดในการให้บริการ</string>
   <string name="source_code">ซอร์สโค้ด</string>
-  <string name="short_credits_text">Intra คือโครงการโอเพนซอร์สแบบทดลองโดย <a href="https://jigsaw.google.com">Jigsaw</a></string>
   <string name="credits_text">Intra ดำเนินการโดย <a href="https://jigsaw.google.com">Jigsaw</a> ตำแหน่ง IP จะขึ้นอยู่กับข้อมูลจาก DB-IP.com.</string>
   <string name="indicator_on">เปิด</string>
   <string name="indicator_off">ปิด</string>
@@ -49,11 +38,26 @@
   <string name="explanation_failing">คำเตือน: คำขอไม่สำเร็จ คุณอาจต้องเลือกเซิร์ฟเวอร์อื่นและรีสตาร์ท Intra</string>
   <string name="system_details">รายละเอียดของระบบ</string>
   <string name="num_requests">การค้นหาทั้งหมด</string>
+  <string name="num_requests_headline">คำขอ DNS จะเกิดขึ้นเมื่ออุปกรณ์ค้นหาที่อยู่ IP ของชื่อโดเมน</string>
+  <string name="num_requests_body">ค่านี้จะแสดงจำนวนคำขอ DNS ทั้งหมดของอุปกรณ์ในขณะที่กำลังใช้งาน Intra โดย Intra จะเข้ารหัสลับคำขอทั้งหมดนี้แล้วส่งไปยังเซิร์ฟเวอร์ที่เชื่อถือได้เพื่อให้คุณได้รับผลลัพธ์ที่ถูกต้อง</string>
   <string name="queries_per_minute">การค้นหาล่าสุด</string>
+  <string name="queries_per_minute_headline">คำขอ DNS จะเกิดขึ้นในช่วงเริ่มต้นการเชื่อมต่อแต่ละครั้ง</string>
+  <string name="queries_per_minute_body">ค่านี้จะแสดงจำนวนคำขอ DNS ของอุปกรณ์ในช่วงนาทีล่าสุด การโหลดหน้าเว็บที่มีความซับซ้อนอาจกำหนดให้ต้องมีคำขอ DNS จำนวนนับร้อย</string>
   <string name="transport_label">การส่งข้อมูลที่เข้ารหัส</string>
-  <string name="insecure_transport_label">การส่งข้อมูลที่ไม่เข้ารหัส</string>
+  <string name="transport_headline">การเข้ารหัสลับจะช่วยป้องกันไม่ให้ผู้อื่นเห็นคำขอของคุณ</string>
+  <string name="transport_body">เมื่อใช้ Intra แอปจะเข้ารหัสลับคำขอ DNS จึงมีเพียงคุณและเซิร์ฟเวอร์ DNS เท่านั้นที่จะเห็นคำขอ DNS ของคุณ โดย Intra จะใช้ DNS ผ่านโปรโตคอล HTTPS ในการเข้ารหัสลับ</string>
+  <string name="default_transport_label">การรับส่งข้อมูลโดยค่าเริ่มต้น</string>
+  <string name="insecure_transport">ไม่ได้เข้ารหัส</string>
+  <string name="insecure_transport_headline">DNS พื้นฐานไม่ได้รับการเข้ารหัส</string>
+  <string name="insecure_transport_body">อุปกรณ์และเครือข่ายส่วนใหญ่จะใช้ DNS พื้นฐานซึ่งไม่ได้เข้ารหัส จึงอาจทำให้ผู้ที่อยู่ในเครือข่ายคนอื่นๆ มองเห็นหรือปรับแก้คำขอ DNS ได้ อุปกรณ์ใหม่ๆ บางรุ่นรองรับ DNS ผ่าน TLS ซึ่งจะเข้ารหัสลับคำขอได้ แต่ป้องกันคุณจากเซิร์ฟเวอร์ที่เป็นอันตรายไม่ได้</string>
   <string name="server_label">เซิร์ฟเวอร์ DNS ที่ปลอดภัย</string>
-  <string name="insecure_server_label">เซิร์ฟเวอร์ DNS ที่ระบุโดยเครือข่าย</string>
+  <string name="server_headline">คุณควรใช้เซิร์ฟเวอร์ DNS ที่เชื่อถือได้</string>
+  <string name="server_body">ช่องนี้จะแสดงชื่อเซิร์ฟเวอร์ DNS ที่ปลอดภัยซึ่งคุณกำลังใช้งานอยู่ โดยคุณเลือกเปลี่ยนเป็นเซิร์ฟเวอร์อื่นได้ในเมนูการตั้งค่า</string>
+  <string name="default_server_label">เซิร์ฟเวอร์ DNS ปัจจุบัน</string>
+  <string name="insecure_server_headline">คุณจะเลือกเซิร์ฟเวอร์ DNS ของตนเองได้</string>
+  <string name="insecure_server_body">เมื่อปิดใช้ Intra อุปกรณ์ส่วนใหญ่จะได้รับการกำหนดค่าล่วงหน้าให้ใช้เซิร์ฟเวอร์ DNS ที่ผู้ให้บริการเครือข่ายของคุณเลือก ช่องนี้จะแสดงที่อยู่ IP ของเซิร์ฟเวอร์ DNS ที่อุปกรณ์ของคุณกำลังใช้งานอยู่ Intra หรือ Android P จะช่วยให้คุณเลือกเซิร์ฟเวอร์ที่ต้องการได้อย่างง่ายดาย</string>
+  <string name="strict_mode_server_headline">คุณได้เลือกเซิร์ฟเวอร์ที่มีความปลอดภัยแล้ว</string>
+  <string name="strict_mode_server_body">ช่องนี้จะแสดงชื่อเซิร์ฟเวอร์ DNS ที่คุณได้กำหนดค่าไว้ในการตั้งค่า DNS แบบส่วนตัวของ Android  เมื่อปิดใช้ Intra แอปของคุณจะส่งคำขอ DNS ไปยังเซิร์ฟเวอร์นี้</string>
   <string name="unknown_server">(เซิร์ฟเวอร์ที่ไม่รู้จัก)</string>
   <string name="show_history">แสดงการค้นหาล่าสุด</string>
   <string name="query_label">การค้นหา</string>
@@ -70,10 +74,6 @@
     ใช้งานร่วมกับ Intra ไม่ได้ โปรดเพิ่มแอปดังกล่าวที่นี่</string>
   <string name="excluded_apps_title">เลือกแอปที่ไม่ต้องการใช้กับ Intra</string>
   <string name="old_android">Android เวอร์ชันที่คุณใช้งานอยู่ไม่มีฟังก์ชันนี้</string>
-  <string name="before_feedback">ช่วยเราปรับปรุง Intra! Intra เป็นผลิตภัณฑ์ระยะเริ่มต้น และเราต้องการให้คุณช่วยทำให้ Intra ดีขึ้น โปรดบอกให้เราว่าสิ่งใดใช้ได้ผลและไม่ได้ผล ขอขอบคุณ!</string>
-  <string name="feedback_hint">ความคิดเห็นของคุณ</string>
-  <string name="after_feedback">ข้อมูลนี้จะส่งไปยังทีม Intra โปรดอย่าใส่ข้อมูลส่วนบุคคลในความคิดเห็นของคุณ</string>
-  <string name="submit_feedback">ส่ง</string>
   <string name="notification_title">การป้องกัน DNS ทำงานอยู่</string>
   <string name="notification_content">แตะเพื่อเปลี่ยนการตั้งค่าการป้องกัน DNS</string>
   <string name="channel_name">การแจ้งเตือนการใช้งานการป้องกัน DNS</string>

--- a/Android/app/src/main/res/values-tr/strings.xml
+++ b/Android/app/src/main/res/values-tr/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Daha açık bir internet deneyimi için daha güvenli bir rota</string>
-  <string name="intro_benefit_body">İnterneti kullandığınızda cihazınızın, adresleri internet iletişim listesinden araması gerekir. Bazen bağlantınız size yanlış adres sunabilir.</string>
-  <string name="intro_manipulation_headline">Yanlış adreslerden korunma</string>
-  <string name="intro_manipulation_body">Intra, DNS bağlantınızı şifreleyerek, çıkmaz yola yönlendiren (DNS manipülasyonu) hatalı adresler almanızı önler.</string>
-  <string name="intro_details_headline">Koruma sağlamak için Intra\'nın ağ trafiğini izlemesi gerekir</string>
-  <string name="intro_details_body">Başlamak için, bağlantı isteğini gördüğünüzde Tamam\'a dokunun. Varsayılan olarak, sorgularınız Google Açık DNS\'e (<a href="https://developers.google.com/speed/public-dns/privacy">Gizlilik Politikası</a>) yönlendirilir. Uygulama ayarlarında başka bir hizmet seçebilirsiniz.</string>
+  <string name="intro_benefit_headline">Daha açık internet erişimi</string>
+  <string name="intro_benefit_body">Intra sizi, haber sitelerine, sosyal medya platformlarına ve mesajlaşma uygulamalarına erişimi engellemek için kullanılan bir siber saldırı olan DNS manipülasyonuna karşı korur.\n\nIntra sizi DNS manipülasyonuna karşı korusa da, Intra\'nın koruma sağlayamayacağı diğer, daha karmaşık engelleme teknikleri ve saldırıları vardır.</string>
+  <string name="intro_manipulation_headline">DNS manipülasyonundan koruma</string>
+  <string name="intro_manipulation_body">Intra, bir web sitesini ziyaret etmek veya bir uygulamayı açmak için ihtiyaç duyduğunuz tam adresleri sağlayan Alan Adı Sistemi (DNS) ile kurduğunuz bağlantıyı korur.\n\nIntra, sonuçların manipüle edilememesi için şifreleme kullanır ve internete güvenle erişmenize yardımcı olur.</string>
+  <string name="intro_details_headline">Son bir şey daha…</string>
+  <string name="intro_details_body">Intra\'nın DNS isteklerinizi korumasına izin vermek için Tamam\'a dokunun. Varsayılan olarak, istekleriniz Google Açık DNS\'e (<a href="https://developers.google.com/speed/public-dns/privacy">Gizlilik Politikası</a>) yönlendirilir. Uygulama ayarlarında başka bir hizmet seçebilirsiniz.</string>
   <string name="intro_back">geri</string>
   <string name="intro_next">sonraki</string>
   <string name="intro_accept">kabul et</string>
-  <string name="about_headline">Güvenilir ve güvenli DNS</string>
-  <string name="about_text">Intra, DNS sorgularınızı güvenli bir HTTPS bağlantısı üzerinden yönlendirerek korur. Bu, yanlış bir siteye
-    yönlendirilmeniz veya tarama deneyiminizin engellenmesi ya da izlenmesi riskini azaltır.</string>
-  <string name="privacy_text">Varsayılan olarak sorgularınız
-    <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>\'e
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Gizlilik Politikası</a>) yönlendirilir.
-    Dilerseniz <a href="https://cloudflare-dns.com">Cloudflare</a>\'i
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Gizlilik Politikası</a>)
-    veya diğer herhangi bir HTTPS üzerinden DNS hizmetini kullanmayı da tercih edebilirsiniz.</string>
-  <string name="accept">Başla</string>
   <string name="drawer_open">Gezinme çekmecesini açın</string>
   <string name="drawer_close">Gezinme çekmecesini kapatın</string>
   <string name="home">Ana ekran</string>
   <string name="settings">Ayarlar</string>
-  <string name="feedback">Geri Bildirim Gönder</string>
   <string name="support">Destek</string>
   <string name="privacy_link">Gizlilik Politikası</string>
   <string name="tos_link">Kullanım Şartları</string>
   <string name="source_code">Kaynak Kodu</string>
-  <string name="short_credits_text">Intra, <a href="https://jigsaw.google.com">Jigsaw</a>\'un sunduğu açık kaynaklı, deneysel bir projedir.</string>
   <string name="credits_text">Intra, <a href="https://jigsaw.google.com">Jigsaw</a> tarafından geliştirilmiştir. IP konumları,
     DB-IP.com sitesinden alınan verilere dayanır.</string>
   <string name="indicator_on">Açık</string>
@@ -51,11 +39,36 @@
   <string name="explanation_failing">Uyarı: Sorgular başarısız oluyor. Farklı bir sunucu seçmeyi ve Intra\'yı yeniden başlatmayı deneyin.</string>
   <string name="system_details">Sistem ayrıntıları</string>
   <string name="num_requests">Şimdiye kadar korunan sorguların sayısı</string>
+  <string name="num_requests_headline">Cihazınız bir alan adı için IP adresi aradığında oluşan DNS sorgularının sayısı</string>
+  <string name="num_requests_body">Bu değer, Intra etkinken cihazınızın gerçekleştirdiği DNS sorgularının toplam sayısını gösterir.
+    Intra, özgün sonuçlar aldığınızdan emin olmak için, bu sorguları şifreler ve güvenilir bir
+    sunucuya gönderir.</string>
   <string name="queries_per_minute">Yeni korunmaya başlayan sorguların sayısı</string>
+  <string name="queries_per_minute_headline">Her bağlantının başında oluşan DNS sorgularının sayısı</string>
+  <string name="queries_per_minute_body">Bu değer, cihazınızın son bir dakika içinde gerçekleştirdiği DNS sorgularının sayısını gösterir.
+    Karmaşık yapıda bir web sayfasının yüklenmesi, yüzden fazla DNS sorgusu gerektirebilir.</string>
   <string name="transport_label">Şifreli aktarım</string>
-  <string name="insecure_transport_label">Şifresiz aktarım</string>
+  <string name="transport_headline">Şifreleme, sorgularınızı meraklı gözlerden korur</string>
+  <string name="transport_body">Intra\'yı kullandığınızda DNS sorgularınız şifrelenir. Böylece, yapmakta olduğunuz DNS sorgularını yalnızca siz ve
+    DNS sunucunuz görebilir. Intra, şifreleme için HTTPS üzerinden DNS protokolünü uygular.</string>
+  <string name="default_transport_label">Varsayılan taşıma</string>
+  <string name="insecure_transport">şifrelenmemiş</string>
+  <string name="insecure_transport_headline">Temel DNS şifresizdir</string>
+  <string name="insecure_transport_body">Çoğu cihaz ve ağ, şifresiz temel DNS kullanır. Dolayısıyla, DNS sorgularınız ağdaki herhangi biri
+    tarafından görülebilir ve değiştirilebilir. Bazı yeni cihazlar, sorgularınızı şifreleyen ancak sunucu
+    kötü amaçlıysa sizi koruyamayan TLS üzerinden DNS\'i destekler.</string>
   <string name="server_label">Güvenli DNS sunucusu</string>
-  <string name="insecure_server_label">Ağ üzerinden sağlanan DNS sunucusu</string>
+  <string name="server_headline">Güvenilir bir DNS sunucusu kullanmayı hak ediyorsunuz</string>
+  <string name="server_body">Bu alanda, kullanmakta olduğunuz güvenli DNS sunucusunun adı gösterilir. Bu alanın değerini,
+    Ayarlar menüsünde farklı bir sunucuyla da değiştirebilirsiniz.</string>
+  <string name="default_server_label">Geçerli DNS sunucusu</string>
+  <string name="insecure_server_headline">Kendi DNS sunucunuzu seçebilirsiniz</string>
+  <string name="insecure_server_body">Intra devre dışı bırakıldığında çoğu cihaz, ağ operatörünüzün seçtiği DNS sunucusunu
+    kullanacak şekilde önceden yapılandırılır. Bu alanda, cihazınızın kullanmakta olduğu DNS sunucusunun IP adresi
+    gösterilir. Intra veya Android P ile, istediğiniz sunucuyu kolayca seçebilirsiniz.</string>
+  <string name="strict_mode_server_headline">Güvenli bir sunucu seçtiniz</string>
+  <string name="strict_mode_server_body">Bu alanda, Android\'deki Gizli DNS ayarında yapılandırdığınız DNS sunucusunun adı
+    gösterilir.  Intra devre dışı bırakıldığında, uygulamalarınız DNS sorgularını bu sunucuya göndermelidir.</string>
   <string name="unknown_server">(bilinmeyen sunucu)</string>
   <string name="show_history">Son sorguları göster</string>
   <string name="query_label">Sorgu</string>
@@ -72,12 +85,6 @@
     uyumlu olmayan bir uygulama varsa buraya ekleyebilirsiniz.</string>
   <string name="excluded_apps_title">Intra\'da hariç tutulacak uygulamaları işaretleyin</string>
   <string name="old_android">Sahip olduğunuz Android sürümünde bu işlev kullanılamaz.</string>
-  <string name="before_feedback">Intra\'yı daha iyi hale getirmemize yardımcı olun! Intra geliştirme aşamasında olan bir üründür. Ürünün daha kullanışlı hale getirilmesi için yardımınıza ihtiyacımız var.
-    Bize, çalışan veya çalışmayan özellikleri bildirmenizi rica ediyoruz. Teşekkürler!</string>
-  <string name="feedback_hint">Geri bildiriminiz</string>
-  <string name="after_feedback">Bu bilgiler Intra ekibine gönderilecektir. Lütfen geri bildiriminize kişisel bilgiler
-    eklemeyin.</string>
-  <string name="submit_feedback">Gönder</string>
   <string name="notification_title">DNS koruması etkin</string>
   <string name="notification_content">DNS koruması ayarını değiştirmek için dokunun</string>
   <string name="channel_name">DNS Koruması Etkin Bildirimi</string>

--- a/Android/app/src/main/res/values-uk/strings.xml
+++ b/Android/app/src/main/res/values-uk/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Безпечніший шлях до відкритого Інтернету</string>
-  <string name="intro_benefit_body">Коли ви користуєтесь Інтернетом, ваш пристрій має шукати адреси в списку інтернет-контактів. Іноді з’єднання може надати вам неправильну адресу.</string>
-  <string name="intro_manipulation_headline">Захист від неправильних адрес</string>
-  <string name="intro_manipulation_body">Додаток Intra шифрує DNS-з’єднання, захищаючи вас від отримання неправильних адрес, які ведуть у глухий кут (маніпуляція DNS).</string>
-  <string name="intro_details_headline">Щоб увімкнути захист, додатку Intra потрібно контролювати мережевий трафік</string>
-  <string name="intro_details_body">Торкніться \"OK\", коли побачите запит на з’єднання, щоб почати роботу. За умовчанням ваші запити будуть скеровуватися на загальнодоступні DNS-сервери Google (<a href="https://developers.google.com/speed/public-dns/privacy">Політика конфіденційності</a>). Ви також можете вибрати інший сервіс у налаштуваннях додатка.</string>
+  <string name="intro_benefit_headline">Більший доступ до Інтернету</string>
+  <string name="intro_benefit_body">Додаток Intra захищає вас від маніпуляцій із DNS – кібератак, які використовуються для блокування доступу до новинних сайтів, соціальних медійних платформ і додатків для обміну повідомленнями.\n\nХоча додаток Intra захищає вас від маніпуляцій із DNS, існують інші, складніші способи блокування й атак, проти яких Intra безсила.</string>
+  <string name="intro_manipulation_headline">Захист від маніпуляцій із DNS</string>
+  <string name="intro_manipulation_body">Додаток Intra захищає ваше з’єднання із системою доменних імен (DNS), яка надає точні адреси для відвідування веб-сайтів або відкриття додатків.\n\nДодаток Intra використовує шифрування, щоб забезпечити недоторканність результатів і надійний доступ до Інтернету.</string>
+  <string name="intro_details_headline">І наостанок…</string>
+  <string name="intro_details_body">Торкніться \"OK\", щоб захистити свої DNS-запити за допомогою додатка Intra. За умовчанням вони будуть скеровуватися на загальнодоступні DNS-сервери Google (<a href="https://developers.google.com/speed/public-dns/privacy">Політика конфіденційності</a>). Ви також можете вибрати інший сервіс у налаштуваннях додатка.</string>
   <string name="intro_back">назад</string>
   <string name="intro_next">далі</string>
   <string name="intro_accept">прийняти</string>
-  <string name="about_headline">Надійні та захищені DNS-сервери</string>
-  <string name="about_text">Intra захищає ваші DNS-запити, скеровуючи їх через безпечне з’єднання (HTTPS). Це знижує ймовірність вашого переходу на неправильний сайт або блокування чи відстеження ваших пошуків.</string>
-  <string name="privacy_text">За умовчанням ваші запити переспрямовуватимуться на
-    <a href="https://developers.google.com/speed/public-dns/">Загальнодоступні DNS-сервери Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Політика конфіденційності</a>).
-    Ви також можете використовувати <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Політика конфіденційності</a>)
-    або іншу службу, що забезпечує DNS поверх HTTPS.</string>
-  <string name="accept">Почати</string>
   <string name="drawer_open">Відкрийте панель навігації</string>
   <string name="drawer_close">Закрийте панель навігації</string>
   <string name="home">Головна</string>
   <string name="settings">Налаштування</string>
-  <string name="feedback">Надіслати відгук</string>
   <string name="support">Підтримка</string>
   <string name="privacy_link">Політика конфіденційності</string>
   <string name="tos_link">Умови використання</string>
   <string name="source_code">Вихідний код</string>
-  <string name="short_credits_text">Intra – це експериментальний проект із відкритим кодом від компанії <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra – розробка компанії <a href="https://jigsaw.google.com">Jigsaw</a>. Місцезнаходження IP-адрес базуються на даних сайту DB-IP.com.</string>
   <string name="indicator_on">Увімк.</string>
   <string name="indicator_off">Вимк.</string>
@@ -46,11 +35,28 @@
   <string name="explanation_failing">Застереження. Запити не виконуються. Виберіть інший сервер і перезапустіть додаток Intra.</string>
   <string name="system_details">Системні дані</string>
   <string name="num_requests">Усі запити</string>
+  <string name="num_requests_headline">DNS-запити надсилаються, коли ваш пристрій шукає IP-адресу для доменного імені</string>
+  <string name="num_requests_body">Це значення показує загальну кількість DNS-запитів, які ваш пристрій виконав, доки додаток Intra був активним. Intra шифрує ці запити й надсилає їх на надійний сервер, щоб забезпечити вас автентичними результатами.</string>
   <string name="queries_per_minute">Останні запити</string>
+  <string name="queries_per_minute_headline">DNS-запити надсилаються на початку кожного з’єднання</string>
+  <string name="queries_per_minute_body">Це значення показує кількість DNS-запитів, які ваш пристрій виконав протягом останньої хвилини. Для завантаження складної веб-сторінки може знадобитися більше сотні DNS-запитів.</string>
   <string name="transport_label">Шифроване передавання</string>
-  <string name="insecure_transport_label">Нешифроване передавання</string>
+  <string name="transport_headline">Шифрування захищає ваші запити від чужих очей</string>
+  <string name="transport_body">Доки додаток Intra активний, ваші DNS-запити шифруються, тому тільки ви й ваш DNS-сервер можете бачити, які DNS-запити надсилаються. Intra реалізує DNS через протокол HTTPS для шифрування.</string>
+  <string name="default_transport_label">Протокол за умовчанням</string>
+  <string name="insecure_transport">незашифрований</string>
+  <string name="insecure_transport_headline">Базовий DNS незашифровано</string>
+  <string name="insecure_transport_body">Більшість пристроїв і мереж використовують базові незашифровані DNS, тому ваші DNS-запити можуть перехоплюватись або змінюватися будь-ким у мережі. Деякі нові пристрої підтримують DNS через протокол TLS, який шифрує ваші запити, але не може захистити їх, якщо сервер зловмисний.</string>
   <string name="server_label">Захищений DNS-сервер</string>
-  <string name="insecure_server_label">DNS-сервер, визначений мережею</string>
+  <string name="server_headline">Використовуйте надійний DNS-сервер</string>
+  <string name="server_body">У цьому полі відображається назва використовуваного захищеного DNS-сервера. Ви також можете змінити сервер у меню \"Налаштування\".</string>
+  <string name="default_server_label">Поточний DNS-сервер</string>
+  <string name="insecure_server_headline">Ви можете вибрати власний DNS-сервер</string>
+  <string name="insecure_server_body">Коли додаток Intra вимкнено, більшість пристроїв (відповідно до попередніх налаштувань) використовують DNS-сервер,
+    указаний вашим оператором мережі. У цьому полі показується ІР-адреса DNS-сервера, який зараз використовує ваш
+    пристрій. У додатку Intra або операційній системі Android P можна легко вибрати будь-який інший сервер.</string>
+  <string name="strict_mode_server_headline">Ви вибрали захищений сервер</string>
+  <string name="strict_mode_server_body">У цьому полі показується назва DNS-сервера, який ви вказали в налаштуванні \"Приватна DNS\" на пристрої Android.  Якщо вимкнути додаток Intra, ваші додатки надсилатимуть DNS-запити на цей сервер.</string>
   <string name="unknown_server">(невідомий сервер)</string>
   <string name="show_history">Показувати останні запити</string>
   <string name="query_label">Запит</string>
@@ -67,10 +73,6 @@
     несумісним з Intra, можете додати його тут.</string>
   <string name="excluded_apps_title">Позначте, що виключити з Intra</string>
   <string name="old_android">Ця функція недоступна у вашій версії Android.</string>
-  <string name="before_feedback">Допоможіть нам удосконалити систему Intra. Зараз Intra перебуває на ранній стадії розробки, тож нам потрібна ваша допомога, щоб покращити цю систему. Розкажіть нам, які функції працюють, а які – ні. Дякуємо!</string>
-  <string name="feedback_hint">Ваш відгук</string>
-  <string name="after_feedback">Ваш відгук буде надіслано команді проекту Intra. Не вказуйте свою особисту інформацію у відгуку.</string>
-  <string name="submit_feedback">Надіслати</string>
   <string name="notification_title">Захист DNS увімкнено</string>
   <string name="notification_content">Торкніться, щоб змінити налаштування захисту DNS</string>
   <string name="channel_name">Сповіщення про наявність захисту DNS</string>

--- a/Android/app/src/main/res/values-vi/strings.xml
+++ b/Android/app/src/main/res/values-vi/strings.xml
@@ -1,33 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">Một đường dẫn an toàn hơn đến một kết nối Internet mở hơn</string>
-  <string name="intro_benefit_body">Khi bạn dùng Internet, thiết bị của bạn cần tra địa chỉ trong \"danh bạ\" của Internet. Đôi khi, kết nối của bạn có thể đưa địa chỉ sai lệch cho bạn.</string>
-  <string name="intro_manipulation_headline">Bảo vệ khỏi địa chỉ sai lệch</string>
-  <string name="intro_manipulation_body">Intra bảo vệ bạn trước việc nhận phải địa chỉ không đúng dẫn bạn vào ngõ cụt (thao túng DNS) bằng cách mã hóa kết nối DNS của bạn.</string>
-  <string name="intro_details_headline">Intra cần giám sát lưu lượng truy cập mạng để cung cấp sự bảo vệ</string>
-  <string name="intro_details_body">Nhấn vào Ok khi bạn thấy yêu cầu kết nối để bắt đầu. Theo mặc định, truy vấn của bạn sẽ được định tuyến đến DNS Google Public (<a href="https://developers.google.com/speed/public-dns/privacy">Chính sách quyền riêng tư</a>). Bạn có thể chọn một dịch vụ khác trong mục cài đặt ứng dụng.</string>
+  <string name="intro_benefit_headline">Khả năng truy cập rộng rãi vào Internet</string>
+  <string name="intro_benefit_body">Intra bảo vệ bạn khỏi thao túng DNS (DNS manipulation), một phương thức tấn công mạng dùng để chặn quyền truy cập vào các trang web tin tức, nền tảng mạng xã hội và ứng dụng nhắn tin.\n\nDù Intra bảo vệ bạn khỏi thao túng DNS, nhưng có những kỹ thuật chặn và tấn công phức tạp hơn mà Intra không thể bảo vệ bạn.</string>
+  <string name="intro_manipulation_headline">Bảo vệ khỏi thao túng DNS</string>
+  <string name="intro_manipulation_body">Intra bảo vệ kết nối của bạn đến Hệ thống tên miền (DNS), hệ thống này cung cấp địa chỉ chính xác mà bạn cần để truy cập vào một trang web hoặc mở một ứng dụng.\n\nIntra sử dụng tính năng mã hóa để đảm bảo không thể thay đổi được kết quả, giúp bạn truy cập vào Internet một cách an toàn.</string>
+  <string name="intro_details_headline">Một điều nữa…</string>
+  <string name="intro_details_body">Nhấn vào Ok để cho phép Intra bảo vệ các yêu cầu DNS của bạn. Theo mặc định, các yêu cầu này sẽ được định tuyến đến DNS Google Public (<a href="https://developers.google.com/speed/public-dns/privacy">Chính sách quyền riêng tư</a>). Bạn có thể chọn một dịch vụ khác trong mục cài đặt ứng dụng.</string>
   <string name="intro_back">quay lại</string>
   <string name="intro_next">tiếp theo</string>
   <string name="intro_accept">chấp nhận</string>
-  <string name="about_headline">DNS trung thực và an toàn</string>
-  <string name="about_text">Intra bảo vệ các truy vấn DNS bằng cách định tuyến các truy vấn này qua kết nối HTTPS an toàn. Điều này làm giảm
-    khả năng bạn bị chuyển đến trang web không chính xác hoặc hoạt động duyệt web của bạn bị chặn hay bị theo dõi.</string>
-  <string name="privacy_text">Theo mặc định, các truy vấn sẽ được chuyển tiếp đến
-    <a href="https://developers.google.com/speed/public-dns/">DNS công khai của Google</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Chính sách quyền riêng tư</a>).
-    Bạn cũng có thể chọn dùng <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Chính sách quyền riêng tư</a>)
-    hoặc bất kỳ dịch vụ DNS qua HTTPS nào khác.</string>
-  <string name="accept">Bắt đầu</string>
   <string name="drawer_open">Mở ngăn di chuyển</string>
   <string name="drawer_close">Đóng ngăn di chuyển</string>
   <string name="home">Màn hình chính</string>
   <string name="settings">Cài đặt</string>
-  <string name="feedback">Gửi phản hồi</string>
   <string name="support">Hỗ trợ</string>
   <string name="privacy_link">Chính sách quyền riêng tư</string>
   <string name="tos_link">Điều khoản dịch vụ</string>
   <string name="source_code">Mã nguồn</string>
-  <string name="short_credits_text">Intra là một dự án nguồn mở thử nghiệm của <a href="https://jigsaw.google.com">Jigsaw</a>.</string>
   <string name="credits_text">Intra do <a href="https://jigsaw.google.com">Jigsaw</a> thiết kế. Các vị trí thông qua IP dựa trên dữ liệu
     từ DB-IP.com.</string>
   <string name="indicator_on">Bật</string>
@@ -51,11 +39,36 @@
   <string name="explanation_failing">Cảnh báo: Truy vấn không thành công. Bạn có thể muốn chọn một máy chủ khác và khởi động lại Intra.</string>
   <string name="system_details">Chi tiết hệ thống</string>
   <string name="num_requests">Số lượng truy vấn được bảo vệ cho tới giờ</string>
+  <string name="num_requests_headline">Truy vấn DNS xảy ra khi thiết bị của bạn tra cứu địa chỉ IP cho một tên miền</string>
+  <string name="num_requests_body">Giá trị này hiển thị tổng số truy vấn DNS mà thiết bị của bạn đã thực hiện trong khi Intra
+    đang hoạt động. Intra mã hóa và gửi các truy vấn này đến một máy chủ đáng tin cậy để đảm bảo bạn sẽ
+    nhận được kết quả xác thực.</string>
   <string name="queries_per_minute">Số lượng truy vấn gần đây</string>
+  <string name="queries_per_minute_headline">Truy vấn DNS xảy ra ở đầu mỗi kết nối</string>
+  <string name="queries_per_minute_body">Giá trị này hiển thị số lượng truy vấn DNS mà thiết bị của bạn đã thực hiện trong một vài phút trước.
+    Việc tải một trang web phức tạp có thể yêu cầu phải thực hiện hơn một trăm truy vấn DNS.</string>
   <string name="transport_label">Đường truyền mã hóa</string>
-  <string name="insecure_transport_label">Đường truyền không được mã hóa</string>
+  <string name="transport_headline">Tính năng mã hóa bảo vệ các truy vấn của bạn khỏi các cặp mắt tò mò</string>
+  <string name="transport_body">Khi bạn sử dụng Intra, các truy vấn DNS của bạn được mã hóa, do đó, chỉ bạn và máy chủ DNS của bạn mới có thể xem
+    các truy vấn DNS mà bạn đang thực hiện. Intra triển khai DNS qua giao thức HTTPS để mã hóa.</string>
+  <string name="default_transport_label">Truyền tải mặc định</string>
+  <string name="insecure_transport">không được mã hóa</string>
+  <string name="insecure_transport_headline">DNS cơ bản không được mã hóa</string>
+  <string name="insecure_transport_body">Hầu hết các thiết bị và mạng đều sử dụng DNS cơ bản, không được mã hóa, vì vậy, các truy vấn DNS của bạn có thể
+    bị bất kỳ ai trên mạng quan sát hoặc sửa đổi. Một số thiết bị mới hỗ trợ DNS qua Bảo mật lớp truyền tải (TLS),
+    tiêu chuẩn này mã hóa các truy vấn của bạn nhưng không thể bảo vệ bạn nếu máy chủ độc hại.</string>
   <string name="server_label">Máy chủ DNS an toàn</string>
-  <string name="insecure_server_label">Máy chủ DNS do mạng cung cấp</string>
+  <string name="server_headline">Bạn xứng đáng được sử dụng một máy chủ DNS đáng tin cậy</string>
+  <string name="server_body">Trường này hiển thị tên của máy chủ DNS bảo mật mà bạn đang sử dụng. Bạn cũng có thể thay đổi sang một
+    máy chủ khác trong menu Cài đặt.</string>
+  <string name="default_server_label">Máy chủ DNS hiện tại</string>
+  <string name="insecure_server_headline">Bạn có thể tự chọn máy chủ DNS của mình</string>
+  <string name="insecure_server_body">Khi tắt Intra, hầu hết các thiết bị được cấu hình sẵn là dùng máy chủ DNS mà nhà mạng của bạn
+    chọn lựa. Trường này hiển thị địa chỉ IP của máy chủ DNS mà thiết bị của bạn hiện đang
+    sử dụng. Với Intra hoặc Android P, bạn có thể dễ dàng lựa chọn máy chủ theo ý mình.</string>
+  <string name="strict_mode_server_headline">Bạn đã chọn một máy chủ bảo mật</string>
+  <string name="strict_mode_server_body">Trường này hiển thị tên của máy chủ DNS bạn đã cấu hình trong mục cài đặt DNS riêng của
+    Android.  Khi bạn tắt Intra, ứng dụng của bạn sẽ gửi truy vấn DNS đến máy chủ này.</string>
   <string name="unknown_server">(máy chủ không xác định)</string>
   <string name="show_history">Hiển thị các truy vấn gần đây</string>
   <string name="query_label">Truy vấn</string>
@@ -72,12 +85,6 @@
     không tương thích với Intra, thì bạn có thể thêm ứng dụng đó tại đây.</string>
   <string name="excluded_apps_title">Đánh dấu các ứng dụng không dùng Intra</string>
   <string name="old_android">Chức năng này không có sẵn trên phiên bản Android của bạn.</string>
-  <string name="before_feedback">Hãy giúp chúng tôi cải tiến Intra! Intra là một sản phẩm đang trong giai đoạn đầu phát triển và chúng tôi cần sự trợ giúp của bạn để cải thiện sản phẩm này.
-    Hãy cho chúng tôi biết tính năng đang hoạt động và tính năng không hiệu quả. Xin cảm ơn!</string>
-  <string name="feedback_hint">Phản hồi của bạn</string>
-  <string name="after_feedback">Thông tin này sẽ được gửi đến nhóm Intra. Vui lòng không đưa bất kỳ thông tin cá nhân nào
-    vào phản hồi của bạn.</string>
-  <string name="submit_feedback">Gửi</string>
   <string name="notification_title">Tính năng bảo vệ DNS đang hoạt động</string>
   <string name="notification_content">Nhấn để thay đổi tùy chọn cài đặt bảo vệ DNS</string>
   <string name="channel_name">Thông báo tính năng bảo vệ DNS đang hoạt động</string>

--- a/Android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/Android/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">更安全的路由助您开启更开放的互联网之旅</string>
-  <string name="intro_benefit_body">当您使用互联网时，您的设备需要在互联网连接列表中查找地址。有时您可能会连接到错误的地址。</string>
-  <string name="intro_manipulation_headline">防止连接到错误的地址</string>
-  <string name="intro_manipulation_body">Intra 可通过加密您的 DNS 连接，防止您连接到无果的错误地址（DNS 篡改）。</string>
-  <string name="intro_details_headline">Intra 需要监测网络流量，以开启保护功能</string>
-  <string name="intro_details_body">当您看到连接请求时，点按“确定”即可开始连接。默认将您的查询路由至 Google 公共 DNS（<a href="https://developers.google.com/speed/public-dns/privacy">隐私权政策</a>）。您可以在应用设置中选择其他服务。</string>
+  <string name="intro_benefit_headline">更开放的互联网访问权限</string>
+  <string name="intro_benefit_body">Intra 可以帮助您防止 DNS 篡改，这种网络攻击会阻止您访问新的网站、社交媒体平台和即时通讯应用。\n\n尽管 Intra 可以防止 DNS 篡改，但是无法针对其他更为复杂的屏蔽技术和攻击方式提供保护。</string>
+  <string name="intro_manipulation_headline">防止 DNS 篡改</string>
+  <string name="intro_manipulation_body">域名系统 (DNS) 为您访问网站或打开应用提供所需的确切地址。Intra 保护您和 DNS 之间的连接。\n\nIntra 使用加密技术确保网址不会被篡改，助您安全访问互联网。</string>
+  <string name="intro_details_headline">最后一点…</string>
+  <string name="intro_details_body">点按“确定”即可让 Intra 保护您的 DNS 请求。默认情况下，这些请求会路由至 Google 公共 DNS（<a href="https://developers.google.com/speed/public-dns/privacy">隐私权政策</a>）。您可以在应用设置中选择其他服务。</string>
   <string name="intro_back">上一页</string>
   <string name="intro_next">下一页</string>
   <string name="intro_accept">接受</string>
-  <string name="about_headline">安全可靠的 DNS</string>
-  <string name="about_text">Intra 通过安全的 HTTPS 连接为您的 DNS 查询建立路由，从而保护这些查询。这会减少将您定向至错误的网站或让您的浏览遭到屏蔽或监视的机率。</string>
-  <string name="privacy_text">默认将您的查询路由至
-    <a href="https://developers.google.com/speed/public-dns/">Google 公共 DNS</a>
-    （<a href="https://developers.google.com/speed/public-dns/privacy">隐私权政策</a>）。
-    您还可以选择使用 <a href="https://cloudflare-dns.com">Cloudflare</a>
-    （<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">隐私权政策</a>）
-    或任何其他 DNS-over-HTTPS 服务。</string>
-  <string name="accept">开始使用</string>
   <string name="drawer_open">打开抽屉式导航栏</string>
   <string name="drawer_close">关闭抽屉式导航栏</string>
   <string name="home">首页</string>
   <string name="settings">设置</string>
-  <string name="feedback">提交反馈</string>
   <string name="support">支持</string>
   <string name="privacy_link">隐私权政策</string>
   <string name="tos_link">服务条款</string>
   <string name="source_code">源代码</string>
-  <string name="short_credits_text">Intra 是由 <a href="https://jigsaw.google.com">Jigsaw</a> 推出的一款实验性开放源代码项目。</string>
   <string name="credits_text">Intra 由 <a href="https://jigsaw.google.com">Jigsaw</a> 开发。IP 位置基于 DB-IP.com 的数据。</string>
   <string name="indicator_on">开启</string>
   <string name="indicator_off">关闭</string>
@@ -47,11 +36,27 @@
   <string name="explanation_failing">警告：查询失败。您可能需要选择其他服务器或重启 Intra。</string>
   <string name="system_details">系统详细信息</string>
   <string name="num_requests">迄今为止的查询数</string>
+  <string name="num_requests_headline">您的设备查找域名的 IP 地址时执行的 DNS 查询数量</string>
+  <string name="num_requests_body">此值显示了在 Intra 启用期间您的设备执行的 DNS 查询总数。Intra 对这些查询进行加密并将其发送至可信服务器，以确保您获得的是真实可信的结果。</string>
   <string name="queries_per_minute">近期查询数</string>
+  <string name="queries_per_minute_headline">每个连接开始时执行的 DNS 查询数量</string>
+  <string name="queries_per_minute_body">此值显示了在最后一分钟内您的设备执行的 DNS 查询数。
+加载一个复杂网页可能需要执行超过一百个 DNS 查询。</string>
   <string name="transport_label">加密的传输</string>
-  <string name="insecure_transport_label">未加密的传输</string>
+  <string name="transport_headline">加密功能可防止他人窥视您的查询</string>
+  <string name="transport_body">使用 Intra 时，您的 DNS 查询受加密保护，因此只有您和您的 DNS 服务器可以看到您执行的 DNS 查询。Intra 会执行 DNS over HTTPS 协议进行加密。</string>
+  <string name="default_transport_label">默认传输</string>
+  <string name="insecure_transport">未加密</string>
+  <string name="insecure_transport_headline">基本 DNS 未加密</string>
+  <string name="insecure_transport_body">大多数设备和网络使用的是基本 DNS，并未加密。因此您的 DNS 查询可被网络上的任何人窥视或修改。部分新设备支持 DNS over TLS，可加密您的查询，但是无法防范恶意服务器的风险。</string>
   <string name="server_label">安全的 DNS 服务器</string>
-  <string name="insecure_server_label">网络提供的 DNS 服务器</string>
+  <string name="server_headline">推荐您使用值得信赖的 DNS 服务器</string>
+  <string name="server_body">此字段显示您正在使用的安全的 DNS 服务器名称。您也可以在“设置”菜单中更改为其他服务器。</string>
+  <string name="default_server_label">当前 DNS 服务器</string>
+  <string name="insecure_server_headline">您可以选择自己的 DNS 服务器</string>
+  <string name="insecure_server_body">如果停用 Intra，根据预设配置，大多数设备会使用您的网络运营商选择的 DNS 服务器。此字段会显示您的设备目前使用的 DNS 服务器的 IP 地址。通过 Intra 或 Android P，您可以轻松选择所需的服务器。</string>
+  <string name="strict_mode_server_headline">您已选择安全的服务器</string>
+  <string name="strict_mode_server_body">此字段会显示您在 Android 私有 DNS 设置中配置的 DNS 服务器的名称。如果停用 Intra，您的应用应该会将 DNS 查询发送至此服务器。</string>
   <string name="unknown_server">（未知服务器）</string>
   <string name="show_history">显示近期的查询</string>
   <string name="query_label">查询</string>
@@ -67,11 +72,6 @@
   <string name="excluded_apps_summary">来自所选应用的 DNS 查询将不通过 Intra 处理。如果某个应用与 Intra 不兼容，您可以将其添加至此处。</string>
   <string name="excluded_apps_title">将应用标记为从 Intra 中排除</string>
   <string name="old_android">您目前的 Android 版本尚不支持此功能。</string>
-  <string name="before_feedback">帮助我们改进 Intra！Intra 这款产品尚处于初级阶段，我们需要您的帮助让它更加完善。
-    请告诉我们它的优缺点，谢谢！</string>
-  <string name="feedback_hint">您的反馈</string>
-  <string name="after_feedback">此信息将会发送至 Intra 团队。请勿在反馈中加入任何个人信息。</string>
-  <string name="submit_feedback">提交</string>
   <string name="notification_title">DNS 保护已启用</string>
   <string name="notification_content">点按即可更改 DNS 保护设置</string>
   <string name="channel_name">DNS 保护启用通知</string>

--- a/Android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/Android/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,32 +1,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="intro_benefit_headline">為更開放的網際網路確保更安全的通路</string>
-  <string name="intro_benefit_body">當你使用網際網路時，裝置必須在網際網路聯絡清單中尋找目的位址，但有時連線會傳回錯誤的位址。</string>
-  <string name="intro_manipulation_headline">錯誤位址防護</string>
-  <string name="intro_manipulation_body">Intra 會將你的 DNS 連線加密，以免不良位址將你導向錯誤的目的網頁 (人為操縱 DNS)。</string>
-  <string name="intro_details_headline">Intra 需要監控網路流量，才能提供防護</string>
-  <string name="intro_details_body">如要開始使用，請於系統顯示連線要求時輕觸 [確定]。根據預設，系統會將你的查詢轉送至 Google 公用 DNS (《<a href="https://developers.google.com/speed/public-dns/privacy">隱私權政策</a>》)。你可以在應用程式設定中選擇其他服務。</string>
+  <string name="intro_benefit_headline">使用更開放的網際網路</string>
+  <string name="intro_benefit_body">Intra 可以防範 DNS 操縱攻擊，這種網路攻擊的目的是阻止使用者存取新聞網站、社交媒體平台和通訊應用程式。\n\n雖然 Intra 可以防止他人操縱你的 DNS 設定，卻無法針對其他更複雜的封鎖技術和攻擊方式提供保護。</string>
+  <string name="intro_manipulation_headline">防範 DNS 操縱攻擊</string>
+  <string name="intro_manipulation_body">你必須使用網域名稱系統 (DNS) 提供的位址才能造訪網站或開啟應用程式，而 Intra 可以保護你和 DNS 之間的連線。\n\nIntra 會使用加密功能防止結果受到操縱，為你提供安全的上網環境。</string>
+  <string name="intro_details_headline">最後一點…</string>
+  <string name="intro_details_body">如要允許 Intra 保護你的 DNS 要求，請輕觸 [確定]。根據預設，系統會將你的查詢轉送至 Google 公用 DNS (《<a href="https://developers.google.com/speed/public-dns/privacy">隱私權政策</a>》)。你可以在應用程式設定中選擇其他服務。</string>
   <string name="intro_back">上一頁</string>
   <string name="intro_next">下一頁</string>
   <string name="intro_accept">接受</string>
-  <string name="about_headline">真實安全的 DNS</string>
-  <string name="about_text">Intra 可以透過安全的 HTTPS 連線轉送 DNS 查詢，藉此保護 DNS 查詢，避免系統將你導向錯誤網站，或是封鎖或偵測到你的瀏覽作業。</string>
-  <string name="privacy_text">根據預設，系統會將你的查詢轉送至
-    <a href="https://developers.google.com/speed/public-dns/">Google 公用 DNS</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">隱私權政策</a>)。
-    你也可以選擇使用 <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">隱私權政策</a>)
-    或任何其他 DNS-over-HTTPS 服務。</string>
-  <string name="accept">開始使用</string>
   <string name="drawer_open">開啟導覽匣</string>
   <string name="drawer_close">關閉導覽匣</string>
   <string name="home">主畫面</string>
   <string name="settings">設定</string>
-  <string name="feedback">提供意見</string>
   <string name="support">支援</string>
   <string name="privacy_link">隱私權政策</string>
   <string name="tos_link">服務條款</string>
   <string name="source_code">原始碼</string>
-  <string name="short_credits_text">Intra 是 <a href="https://jigsaw.google.com">Jigsaw</a> 的一項實驗性開放原始碼專案。</string>
   <string name="credits_text">Intra 是由 <a href="https://jigsaw.google.com">Jigsaw</a> 開發製作。IP 位置資料來源：DB-IP.com。</string>
   <string name="indicator_on">開啟</string>
   <string name="indicator_off">關閉</string>
@@ -48,11 +37,33 @@
   <string name="explanation_failing">警告：查詢失敗。請選擇其他伺服器並重新啟動 Intra。</string>
   <string name="system_details">系統詳細資訊</string>
   <string name="num_requests">所有加密查詢</string>
+  <string name="num_requests_headline">你的裝置在尋找網域名稱的 IP 位址時傳送的 DNS 查詢數</string>
+  <string name="num_requests_body">這個值代表你的裝置在 Intra 啟用狀態下所執行的 DNS 查詢總數。
+    Intra 會將這些查詢加密並傳送至可信的伺服器，
+    確保你獲得可靠的結果。</string>
   <string name="queries_per_minute">最近的查詢</string>
+  <string name="queries_per_minute_headline">系統會在每次開始連線時傳送 DNS 查詢</string>
+  <string name="queries_per_minute_body">這個值代表你的裝置在前一分鐘內執行的 DNS 查詢數。
+    載入複雜網頁可能需執行超過一百個 DNS 查詢。</string>
   <string name="transport_label">加密的傳輸方式</string>
-  <string name="insecure_transport_label">未加密的傳輸方式</string>
+  <string name="transport_headline">利用加密功能防止他人窺視你的查詢</string>
+  <string name="transport_body">使用 Intra 時，你的 DNS 查詢會受到加密，因此只有你和你的 DNS 伺服器可
+    查看你的 DNS 查詢資料。Intra 會透過 HTTPS 通訊協定為 DNS 進行加密。</string>
+  <string name="default_transport_label">預設傳輸方式</string>
+  <string name="insecure_transport">未加密</string>
+  <string name="insecure_transport_headline">基本 DNS 未加密</string>
+  <string name="insecure_transport_body">多數裝置和網路使用的都是未加密的基本 DNS，因此網路上的任何人
+    都可能窺視或修改你的 DNS 查詢。有些新型裝置支援 DNS over TLS 技術，
+    可以加密你的查詢，但無法防止惡意伺服器所產生的威脅。</string>
   <string name="server_label">安全的 DNS 伺服器</string>
-  <string name="insecure_server_label">網路提供的 DNS 伺服器</string>
+  <string name="server_headline">你應該使用值得信賴的 DNS 伺服器</string>
+  <string name="server_body">這個欄位顯示的是你目前使用的安全 DNS 伺服器名稱，
+    你也可以在「設定」選單中改成其他伺服器。</string>
+  <string name="default_server_label">目前的 DNS 伺服器</string>
+  <string name="insecure_server_headline">你可以選擇自己的 DNS 伺服器</string>
+  <string name="insecure_server_body">如果停用 Intra，大多數裝置都已預先設定為使用你的網路業者所指定的 DNS 伺服器。這個欄位會顯示你的裝置目前使用的 DNS 伺服器 IP 位址。你可以透過 Intra 或 Android P 輕鬆選取想要使用的伺服器。</string>
+  <string name="strict_mode_server_headline">你已選擇安全的伺服器</string>
+  <string name="strict_mode_server_body">這個欄位會顯示你在 Android 私人 DNS 設定中指定的 DNS 伺服器名稱。如果停用 Intra，你的應用程式會將 DNS 查詢傳送至這部伺服器。</string>
   <string name="unknown_server">(不明伺服器)</string>
   <string name="show_history">顯示最近的查詢</string>
   <string name="query_label">查詢</string>
@@ -68,11 +79,6 @@
   <string name="excluded_apps_summary">由所選應用程式發送的 DNS 查詢將不會經過 Intra 處理。你可以將和 Intra 不相容的應用程式新增到這裡。</string>
   <string name="excluded_apps_title">從 Intra 排除應用程式</string>
   <string name="old_android">你的 Android 版本尚未支援這項功能。</string>
-  <string name="before_feedback">歡迎協助我們改善 Intra！本產品目前仍在早期開發階段，為了提升服務品質，我們需要你的一臂之力。
-    請將你認為實用和不實用的功能告訴我們，謝謝！</string>
-  <string name="feedback_hint">你的意見回饋</string>
-  <string name="after_feedback">這項資訊將傳送給 Intra 小組。請勿在意見回饋中附上任何個人資訊。</string>
-  <string name="submit_feedback">提交</string>
   <string name="notification_title">DNS 保護機制已生效</string>
   <string name="notification_content">輕觸這裡即可變更 DNS 保護機制設定</string>
   <string name="channel_name">DNS 保護機制啟用通知</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
     different server in the Settings menu.
   </string>
 
-  <string name="insecure_server_label"
+  <string name="default_server_label"
           description="This text appears under the name of the insecure server currently in use.">
     Current DNS server
   </string>
@@ -267,8 +267,17 @@
 
   <string name="insecure_server_body">
     When Intra is disabled, most devices are pre-configured to use the DNS server your network
-    operator picks. This field shows the DNS server your device is currently using. With Intra or
-    Android P, you can easily select a server of your choice.
+    operator picks. This field shows the IP address of the DNS server that your device is currently
+    using. With Intra or Android P, you can easily select a server of your choice.
+  </string>
+
+  <string name="strict_mode_server_headline">
+    You\'ve selected a secure server
+  </string>
+
+  <string name="strict_mode_server_body">
+    This field shows the name of the DNS server that you configured in Android\'s Private DNS
+    setting.  When Intra is disabled, your apps should send DNS queries to this server.
   </string>
 
   <string name="unknown_server"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -217,7 +217,7 @@
     what DNS queries you are making.  Intra implements the DNS over HTTPS protocol for encryption.
   </string>
 
-  <string name="insecure_transport_label"
+  <string name="default_transport_label"
           description="This text appears under the name of the DNS protocol in use when Intra is off.  Currently,
   that is usually 'unencrypted'.">
     Default transport
@@ -258,7 +258,7 @@
 
   <string name="insecure_server_label"
           description="This text appears under the name of the insecure server currently in use.">
-    Network-provided DNS server
+    Current DNS server
   </string>
 
   <string name="insecure_server_headline">
@@ -267,7 +267,7 @@
 
   <string name="insecure_server_body">
     When Intra is disabled, most devices are pre-configured to use the DNS server your network
-    operator picks. This field shows the IP address your device is currently using. With Intra or
+    operator picks. This field shows the DNS server your device is currently using. With Intra or
     Android P, you can easily select a server of your choice.
   </string>
 

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -224,9 +224,18 @@
   </string>
 
   <string name="insecure_transport_label"
-          description="This text appears under the name of the insecure protocol currently in use.  Currently,
-  that is always 'dns'.">
-    Unencrypted transport
+          description="This text appears under the name of the DNS protocol in use when Intra is off.  Currently,
+  that is usually 'unencrypted'.">
+    Default transport
+  </string>
+
+  <string name="insecure_transport" description="Indicates that normal, insecure DNS is in use.">
+    unencrypted
+  </string>
+
+  <string name="tls_transport" description="Indicates that 'DNS over TLS' protocol is in use"
+      translatable="false">
+    tls
   </string>
 
   <string name="server_label"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -3,27 +3,27 @@
 
   <!-- Intro text -->
   <string name="intro_benefit_headline" description="Headline for intro page describing key benefit">
-    A safer route to a more open internet
+    More open internet access
   </string>
 
   <string name="intro_benefit_body" description="Body text for intro page describing key benefit">
-    When you use the internet, your device needs to look up addresses in an internet contact list. Sometimes your connection can give you the wrong address.
+    Intra protects you from DNS manipulation, a cyber attack used to block access to news sites, social media platforms and messaging apps.\n\nWhile Intra protects you against DNS manipulation, there are other, more complicated blocking techniques and attacks that Intra doesn\'t protect against.
   </string>
 
   <string name="intro_manipulation_headline" description="Headline for intro page describing manipulation">
-    Protection from wrong addresses
+    Protection from DNS manipulation
   </string>
 
   <string name="intro_manipulation_body" description="Body text for intro page describing manipulation">
-    Intra protects you from getting bad addresses that lead to dead ends (DNS manipulation) by encrypting your DNS connection.
+    Intra protects your connection to the Domain Name System (DNS), which provides the exact addresses you need to visit a website or open an app.\n\nIntra uses encryption to ensure that results can\’t be manipulated, helping you safely access the internet.
   </string>
 
   <string name="intro_details_headline" description="Headline for intro page describing permissions and privacy">
-    Intra needs to monitor network traffic to enable protection
+    One last thing&#8230;
   </string>
 
   <string name="intro_details_body" description="Body text for intro page describing permissions and privacy">
-    Tap OK when you see the connection request to get started. By default, your queries will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.
+    Tap OK to allow Intra to protect your DNS requests. By default, they will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.
   </string>
 
   <string name="intro_back" description="Button label to see the previous page of introduction">
@@ -262,12 +262,13 @@
   </string>
 
   <string name="insecure_server_headline">
-    Your network assigns you a DNS server without your input
+    You can choose your own DNS server
   </string>
 
   <string name="insecure_server_body">
-    When Intra is disabled, your device uses whichever DNS server the network operator tells it to
-    use.  This field shows the IP address of your default network\'s DNS server.
+    When Intra is disabled, most devices are pre-configured to use the DNS server your network
+    operator picks. This field shows the IP address your device is currently using. With Intra or
+    Android P, you can easily select a server of your choice.
   </string>
 
   <string name="unknown_server"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
   </string>
 
   <string name="intro_details_body" description="Body text for intro page describing permissions and privacy">
-    Tap OK when you see the conection request to get started. By default, your queries will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.
+    Tap OK when you see the connection request to get started. By default, your queries will be routed to Google Public DNS (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>). You can choose another service in the app settings.
   </string>
 
   <string name="intro_back" description="Button label to see the previous page of introduction">
@@ -37,30 +37,6 @@
   <string name="intro_accept"
           description="Button label to acknowledge legal terms and VPN access permission request">
     accept
-  </string>
-
-  <string name="about_headline"
-          description="Headline for the welcome screen.">Honest and secure DNS</string>
-
-  <string name="about_text"
-          description="Text for the welcome screen.">
-    Intra protects your DNS queries by routing them over a secure HTTPS connection. This reduces the
-    chance that you will be sent to the wrong site, or have your browsing blocked or observed.
-  </string>
-
-  <string name="privacy_text"
-          description="Privacy text for the welcome screen.">
-    By default, your queries will be routed to
-    <a href="https://developers.google.com/speed/public-dns/">Google Public DNS</a>
-    (<a href="https://developers.google.com/speed/public-dns/privacy">Privacy Policy</a>).
-    You can also choose to use <a href="https://cloudflare-dns.com">Cloudflare</a>
-    (<a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/">Privacy Policy</a>)
-    or any other DNS-over-HTTPS service.
-  </string>
-
-  <string name="accept"
-          description="Button label to exit the welcome screen.">
-    Get Started
   </string>
 
   <string name="drawer_open"
@@ -83,11 +59,6 @@
     Settings
   </string>
 
-  <string name="feedback"
-          description="Menu entry for sending error reports and complaints to the developers.">
-    Submit Feedback
-  </string>
-
   <string name="support"
           description="Menu entry that links to documentation and interactive support.">
     Support
@@ -106,11 +77,6 @@
   <string name="source_code"
           description="Link to the source code for this app.">
     Source Code
-  </string>
-
-  <string name="short_credits_text"
-          description="Jigsaw credits. 'Jigsaw' and 'Intra' are not translatable.">
-    Intra is an experimental open source project by <a href="https://jigsaw.google.com">Jigsaw</a>.
   </string>
 
   <string name="credits_text"
@@ -212,15 +178,43 @@
     Lifetime queries
   </string>
 
+  <string name="num_requests_headline">
+    DNS queries happen when your device looks up the IP address for a domain name
+  </string>
+
+  <string name="num_requests_body">
+    This value shows the total number of DNS queries that your device has performed while Intra was
+    active.  Intra encrypts these queries and sends them to a trusted server to make sure you\'re
+    getting authentic results.
+  </string>
+
   <string name="queries_per_minute"
           description="This text appears under the number of queries protected in the past minute.">
     Recent queries
+  </string>
+
+  <string name="queries_per_minute_headline">
+    DNS queries happen at the beginning of each connection
+  </string>
+
+  <string name="queries_per_minute_body">
+    This value shows the number of DNS queries that your device has performed in the last minute.
+    Loading a complex webpage can require over a hundred DNS queries.
   </string>
 
   <string name="transport_label"
           description="This text appears under the name of the secure protocol currently in use.  Currently, that
    is always 'https'.">
     Encrypted transport
+  </string>
+
+  <string name="transport_headline">
+    Encryption protects your queries from prying eyes
+  </string>
+
+  <string name="transport_body">
+    When you use Intra, your DNS queries are encrypted, so that only you and your DNS server can see
+    what DNS queries you are making.  Intra implements the DNS over HTTPS protocol for encryption.
   </string>
 
   <string name="insecure_transport_label"
@@ -238,14 +232,42 @@
     tls
   </string>
 
+  <string name="insecure_transport_headline">
+    Basic DNS is unencrypted
+  </string>
+
+  <string name="insecure_transport_body">
+    Most devices and networks use basic DNS, which is unencrypted, so your DNS queries could be
+    observed or modified by anyone on the network.  Some new devices support DNS over TLS, which
+    encrypts your queries but can\'t protect you if the server is malicious.
+  </string>
+
   <string name="server_label"
           description="This text appears under the domain name of the secure server currently in use, e.g. 'dns.google.com'.">
     Secure DNS server
   </string>
 
+  <string name="server_headline">
+    You deserve to use a trustworthy DNS server
+  </string>
+
+  <string name="server_body">
+    This field shows the name of the secure DNS server that you\'re using.  You can also change to a
+    different server in the Settings menu.
+  </string>
+
   <string name="insecure_server_label"
           description="This text appears under the name of the insecure server currently in use.">
     Network-provided DNS server
+  </string>
+
+  <string name="insecure_server_headline">
+    Your network assigns you a DNS server without your input
+  </string>
+
+  <string name="insecure_server_body">
+    When Intra is disabled, your device uses whichever DNS server the network operator tells it to
+    use.  This field shows the IP address of your default network\'s DNS server.
   </string>
 
   <string name="unknown_server"
@@ -329,28 +351,6 @@
   <string name="old_android"
           description="Shown when a user-interface element requires a newer OS version">
     This functionality is not available on your version of Android.
-  </string>
-
-  <string name="before_feedback"
-          description="Text that appears above the feedback text entry field.">
-    Help us improve Intra! Intra is an early-stage product and we need your help to make it better.
-    Tell us what\'s working, and what\'s not.  Thanks!
-  </string>
-
-  <string name="feedback_hint"
-          description="Hint that appears in the text field where the user will type their complaint or error.">
-    Your feedback
-  </string>
-
-  <string name="after_feedback"
-          description="Text that appears after the feedback text entry field, warning users not to include
-  personally identifying information that could violate their privacy.">
-    This information will be sent to the Intra team.  Please do not include any personal information
-    in your feedback.
-  </string>
-
-  <string name="submit_feedback" description="Text on the button to submit feedback.">
-    Submit
   </string>
 
   <string name="notification_title"


### PR DESCRIPTION
This makes all the info tiles clickable, revealing a detailed explanation of each tile.

Note that the strings have already been reviewed.