### PR TITLE
Disable Firebase metrics in debug builds

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -37,9 +37,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.config
+            resValue("bool", "FIREBASE_ENABLED", "true")
         }
         debug {
             pseudoLocalesEnabled true
+            resValue("bool", "FIREBASE_ENABLED", "false")
         }
     }
     testOptions {

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,13 @@
             </intent-filter>
         </receiver>
 
+        <meta-data
+            android:name="firebase_crash_collection_enabled"
+            android:value="@bool/FIREBASE_ENABLED"/>
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="@bool/FIREBASE_ENABLED" />
+
         <!-- Uncomment the below line for network performance debug logging -->
         <!-- <meta-data android:name="firebase_performance_logcat_enabled" android:value="true" /> -->
     </application>


### PR DESCRIPTION
This helps to avoid polluting the metrics during development.

Fixes #57