### PR TITLE
Make OverrideSocksHandler public

### DIFF
--- a/Android/app/src/main/java/app/intra/net/socks/OverrideSocksHandler.java
+++ b/Android/app/src/main/java/app/intra/net/socks/OverrideSocksHandler.java
@@ -47,7 +47,7 @@ import sockslib.server.msg.ServerReply;
  * have both behaviors.  This class is separate from UdpOverrideSocksHandler to make the code more
  * comprehensible.
  */
-class OverrideSocksHandler extends UdpOverrideSocksHandler {
+public class OverrideSocksHandler extends UdpOverrideSocksHandler {
   // Names for the upload and download pipes for monitoring.
   private static final String UPLOAD = "upload";
   private static final String DOWNLOAD = "download";


### PR DESCRIPTION
This fixes a 100% fatal crash, because OverrideSocksHandler
was not accessible from the place where it is instantiated,
in sockslib.  This was not caught in testing because sockslib
uses a reflection-based construction pattern that is not
checked by the compiler, and the relevant runtime visibility
check is not enforced in debug builds.