### PR TITLE
Disable IPv6 support again

### DIFF
--- a/Android/app/src/main/java/app/intra/net/socks/SocksVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/socks/SocksVpnAdapter.java
@@ -105,7 +105,11 @@ public class SocksVpnAdapter extends VpnAdapter {
     final String fakeDnsIp = LanIp.DNS.make(IPV4_TEMPLATE);
     final String fakeDnsAddress = fakeDnsIp + ":" + DNS_DEFAULT_PORT;
     final String ipv4Router = LanIp.ROUTER.make(IPV4_TEMPLATE);
-    final String ipv6Router = LanIp.ROUTER.make(IPV6_TEMPLATE);
+    // Disable IPv6 due to apparent lack of Happy Eyeballs fallback in the Facebook apps, when
+    // using Intra on IPv4-only networks.
+    // TODO: Re-enable IPv6 once we solve this compatibility problem.  This might require swapping
+    // the tunfd to enable/disable v6 when moving between v4only and non-v4only networks.
+    final String ipv6Router = null;
 
     // Proxy parameters
     InetSocketAddress fakeDns = new InetSocketAddress(fakeDnsIp, DNS_DEFAULT_PORT);


### PR DESCRIPTION
It appears that Facebook Messenger, and the other Facebook apps,
don't work with Intra's IPv6 behavior when the underlying network
is v4-only.  We'll have to figure out why Happy Eyeballs isn't
working before we can re-enable IPv6.