### PR TITLE
Mark EARLY_RESET events with a timeout indication

### DIFF
--- a/Android/app/src/main/java/app/intra/sys/Names.java
+++ b/Android/app/src/main/java/app/intra/sys/Names.java
@@ -31,6 +31,7 @@ public enum Names {
   RESULT,
   RETRY,
   SPLIT,
+  TIMEOUT,
   TCP_HANDSHAKE_MS,
   TRANSACTION,
 }


### PR DESCRIPTION
This will allow us to distinguish retries that were triggered by
a timeout from retries that were triggered by a fast failure.

(This is a simplified alternative to #141, which we abandoned.)