### PR TITLE
Count upload and download bytes separately

### DIFF
--- a/Android/app/src/main/java/app/intra/net/socks/OverrideSocksHandler.java
+++ b/Android/app/src/main/java/app/intra/net/socks/OverrideSocksHandler.java
@@ -199,7 +199,8 @@ public class OverrideSocksHandler extends UdpOverrideSocksHandler {
       // - FIRST_BYTE_MS : Time between socket open and first byte from server, in milliseconds.
 
       Bundle event = new Bundle();
-      event.putInt(Param.VALUE, listener.uploadBytes + listener.downloadBytes);
+      event.putLong(Names.UPLOAD.name(), listener.uploadBytes);
+      event.putLong(Names.DOWNLOAD.name(), listener.downloadBytes);
 
       int port = listener.port;
       if (port >= 0) {

--- a/Android/app/src/main/java/app/intra/sys/Names.java
+++ b/Android/app/src/main/java/app/intra/sys/Names.java
@@ -23,6 +23,7 @@ public enum Names {
   BYTES,
   CHUNKS,
   DNS_STATUS,
+  DOWNLOAD,
   DURATION,
   EARLY_RESET,
   FIRST_BYTE_MS,
@@ -34,4 +35,5 @@ public enum Names {
   TIMEOUT,
   TCP_HANDSHAKE_MS,
   TRANSACTION,
+  UPLOAD,
 }


### PR DESCRIPTION
This also resolves an issue with the Firebase "value"
parameter, which is intended for use with currency, not
arbitrary metrics.