### PR TITLE
Workaround for Android platform bug

### DIFF
--- a/Android/third_party/THIRD_PARTY.md
+++ b/Android/third_party/THIRD_PARTY.md
@@ -4,3 +4,4 @@ of https://github.com/fengyouchao/sockslib, with the following changes:
  * Any files related to MongoDB or JDBC have been removed, as these are not relevant to Intra.
  * Small fixes for https://github.com/fengyouchao/sockslib/issues/14 and related issues in
    StreamPipe.java.
+ * Workaround for a NullPointerException in Android's DatagramSocket.receive().

--- a/Android/third_party/sockslib/src/main/java/sockslib/server/UDPRelayServer.java
+++ b/Android/third_party/sockslib/src/main/java/sockslib/server/UDPRelayServer.java
@@ -148,7 +148,13 @@ public class UDPRelayServer implements Runnable {
       byte[] buffer = new byte[bufferSize];
       while (running) {
         DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
-        server.receive(packet);
+        try {
+          server.receive(packet);
+        } catch (NullPointerException e) {
+          // Workaround for an Android platform bug: sending on a closed socket can produce a
+          // NullPointerException instead of an IOException.  See https://android.googlesource.com/platform/libcore/+/6dd21e692ae87b75e49b23ffbecc6964604f466a%5E%21/
+          throw new IOException(e);
+        }
         if (isFromClient(packet)) {
           datagramPacketHandler.decapsulate(packet);
           server.send(packet);


### PR DESCRIPTION
DatagramSocket.receive() is supposed to throw an IOException when
used after the socket is closed.  However, on Android it sometimes
throws a NullPointerException instead.  This change converts the
NullPointerException to an IOException.

Fixes #160