### PR TITLE
Fix crash in debug builds

### DIFF
--- a/Android/app/src/main/java/app/intra/net/dns/DnsUdpQuery.java
+++ b/Android/app/src/main/java/app/intra/net/dns/DnsUdpQuery.java
@@ -18,7 +18,6 @@ package app.intra.net.dns;
 import android.os.SystemClock;
 import android.util.Log;
 import app.intra.sys.LogWrapper;
-import com.crashlytics.android.Crashlytics;
 import java.net.InetAddress;
 import java.net.ProtocolException;
 
@@ -45,18 +44,18 @@ public class DnsUdpQuery {
     try {
       dnsPacket = new DnsPacket(dnsPacketData);
     } catch (ProtocolException e) {
-      LogWrapper.logcat(Log.INFO, LOG_TAG, "Received invalid DNS request");
+      LogWrapper.log(Log.INFO, LOG_TAG, "Received invalid DNS request");
       return null;
     }
     if (!dnsPacket.isNormalQuery() && !dnsPacket.isResponse()) {
-      Crashlytics.log(Log.INFO, LOG_TAG, "Dropping strange DNS query");
+      LogWrapper.log(Log.INFO, LOG_TAG, "Dropping strange DNS query");
       return null;
     }
 
     dnsUdpQuery.type = dnsPacket.getQueryType();
     dnsUdpQuery.name = dnsPacket.getQueryName();
     if (dnsUdpQuery.name == null || dnsUdpQuery.type == 0) {
-      Crashlytics.log(Log.INFO, LOG_TAG, "No question in DNS packet");
+      LogWrapper.log(Log.INFO, LOG_TAG, "No question in DNS packet");
       return null;
     }
     dnsUdpQuery.requestId = dnsPacket.getId();

--- a/Android/app/src/main/java/app/intra/net/doh/Resolver.java
+++ b/Android/app/src/main/java/app/intra/net/doh/Resolver.java
@@ -18,7 +18,6 @@ package app.intra.net.doh;
 import android.util.Log;
 import app.intra.net.dns.DnsUdpQuery;
 import app.intra.sys.LogWrapper;
-import com.crashlytics.android.Crashlytics;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.nio.BufferOverflowException;
@@ -93,13 +92,13 @@ public class Resolver {
     public void onFailure(Call call, IOException e) {
       transaction.status = call.isCanceled() ?
           Transaction.Status.CANCELED : Transaction.Status.SEND_FAIL;
-      LogWrapper.logcat(Log.WARN, LOG_TAG, "Failed to read HTTPS response: " + e.toString());
+      LogWrapper.log(Log.WARN, LOG_TAG, "Failed to read HTTPS response: " + e.toString());
       if (e instanceof SocketTimeoutException) {
-        Crashlytics.log(Log.WARN, LOG_TAG, "Workaround for OkHttp3 #3146: resetting");
+        LogWrapper.log(Log.WARN, LOG_TAG, "Workaround for OkHttp3 #3146: resetting");
         try {
           serverConnection.reset();
         } catch (NullPointerException npe) {
-          Crashlytics.log(Log.WARN, LOG_TAG,
+          LogWrapper.log(Log.WARN, LOG_TAG,
               "Unlikely race: Null server connection at reset.");
         }
       }
@@ -123,7 +122,7 @@ public class Resolver {
       try {
         writeRequestIdToDnsResponse(dnsResponse, dnsUdpQuery.requestId);
       } catch (BufferOverflowException e) {
-        Crashlytics.log(Log.WARN, LOG_TAG, "ID replacement failed");
+        LogWrapper.log(Log.WARN, LOG_TAG, "ID replacement failed");
         transaction.status = Transaction.Status.BAD_RESPONSE;
         return;
       }
@@ -131,7 +130,7 @@ public class Resolver {
       if (parsedDnsResponse != null) {
         Log.d(LOG_TAG, "RNAME: " + parsedDnsResponse.name + " NAME: " + dnsUdpQuery.name);
         if (!dnsUdpQuery.name.equals(parsedDnsResponse.name)) {
-          Crashlytics.log(Log.ERROR, LOG_TAG, "Mismatch in request and response names.");
+          LogWrapper.log(Log.ERROR, LOG_TAG, "Mismatch in request and response names.");
           transaction.status = Transaction.Status.BAD_RESPONSE;
           return;
         }

--- a/Android/app/src/main/java/app/intra/net/socks/LocalhostResolver.java
+++ b/Android/app/src/main/java/app/intra/net/socks/LocalhostResolver.java
@@ -56,10 +56,10 @@ class LocalhostResolver extends Thread implements ResponseWriter {
       SocketAddress bindaddr = new InetSocketAddress(localhost, 0);
       socket = new DatagramSocket(bindaddr);
     } catch (UnknownHostException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
       return null;
     } catch (SocketException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
       return null;
     }
     return new LocalhostResolver(vpnService, socket);
@@ -79,7 +79,7 @@ class LocalhostResolver extends Thread implements ResponseWriter {
       byte[] data = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getLength());
       DnsUdpQuery dnsRequest = DnsUdpQuery.fromUdpBody(data);
       if (dnsRequest == null) {
-        LogWrapper.logcat(Log.ERROR, LOG_TAG, "Failed to parse DNS request");
+        LogWrapper.log(Log.ERROR, LOG_TAG, "Failed to parse DNS request");
         continue;
       }
       Log.d(
@@ -129,7 +129,7 @@ class LocalhostResolver extends Thread implements ResponseWriter {
       try {
         socket.send(responsePacket);
       } catch (IOException e) {
-        LogWrapper.report(e);
+        LogWrapper.logException(e);
         transaction.status = Transaction.Status.INTERNAL_ERROR;
       }
     }

--- a/Android/app/src/main/java/app/intra/net/socks/SafeTun2Socks.java
+++ b/Android/app/src/main/java/app/intra/net/socks/SafeTun2Socks.java
@@ -105,7 +105,7 @@ class SafeTun2Socks  {
         try {
           thread.join(startTime + STARTUP_WAIT_MS - now);
         } catch (InterruptedException e) {
-          LogWrapper.report(e);
+          LogWrapper.logException(e);
         }
       }
       Tun2SocksJni.stop();
@@ -113,7 +113,7 @@ class SafeTun2Socks  {
     try {
       thread.join();
     } catch (InterruptedException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
     }
     if (started) {
       globalSemaphore.release();

--- a/Android/app/src/main/java/app/intra/net/socks/SocksServer.java
+++ b/Android/app/src/main/java/app/intra/net/socks/SocksServer.java
@@ -63,7 +63,7 @@ class SocksServer extends BasicSocksProxyServer {
       override.setDns(fakeDns, trueDns);
       override.setContext(context);
     } else {
-      LogWrapper.logcat(Log.WARN, LOG_TAG, "Foreign handler");
+      LogWrapper.log(Log.WARN, LOG_TAG, "Foreign handler");
     }
   }
 

--- a/Android/app/src/main/java/app/intra/net/socks/SocksVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/socks/SocksVpnAdapter.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 import app.intra.net.VpnAdapter;
 import app.intra.sys.IntraVpnService;
 import app.intra.sys.LogWrapper;
-import com.crashlytics.android.Crashlytics;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -120,7 +119,7 @@ public class SocksVpnAdapter extends VpnAdapter {
     try {
       localhost = Inet4Address.getByAddress(new byte[]{127, 0, 0, 1});
     } catch (UnknownHostException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
       return;
     }
 
@@ -132,7 +131,7 @@ public class SocksVpnAdapter extends VpnAdapter {
     try {
       proxy.start();
     } catch (IOException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
       return;
     }
 
@@ -169,7 +168,7 @@ public class SocksVpnAdapter extends VpnAdapter {
           .addDisallowedApplication(vpnService.getPackageName())
           .establish();
     } catch (Exception e) {
-      Crashlytics.logException(e);
+      LogWrapper.logException(e);
       return null;
     }
   }
@@ -184,13 +183,13 @@ public class SocksVpnAdapter extends VpnAdapter {
       join();
     } catch (InterruptedException e) {
       // This is weird: the calling thread has _also_ been interrupted.
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
     }
 
     try {
       tunFd.close();
     } catch (IOException e) {
-      LogWrapper.report(e);
+      LogWrapper.logException(e);
     }
   }
 }

--- a/Android/app/src/main/java/app/intra/sys/AutoStarter.java
+++ b/Android/app/src/main/java/app/intra/sys/AutoStarter.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.net.VpnService;
 import android.util.Log;
 import app.intra.ui.MainActivity;
-import com.crashlytics.android.Crashlytics;
 
 /**
  * Broadcast receiver that runs on boot, and also when the app is restarted due to an update.
@@ -34,14 +33,14 @@ public class AutoStarter extends BroadcastReceiver {
     if (!Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
       return;
     }
-    Crashlytics.log(Log.DEBUG, LOG_TAG, "Boot event");
+    LogWrapper.log(Log.DEBUG, LOG_TAG, "Boot event");
     VpnController controller = VpnController.getInstance();
     VpnState state = controller.getState(context);
     if (state.activationRequested && !state.on) {
-      Crashlytics.log(Log.DEBUG, LOG_TAG, "Autostart enabled");
+      LogWrapper.log(Log.DEBUG, LOG_TAG, "Autostart enabled");
       if (VpnService.prepare(context) != null) {
         // prepare() returns a non-null intent if VPN permission has not been granted.
-        Crashlytics.log(Log.WARN, LOG_TAG, "VPN permission not granted.  Starting UI.");
+        LogWrapper.log(Log.WARN, LOG_TAG, "VPN permission not granted.  Starting UI.");
         Intent startIntent = new Intent(context, MainActivity.class);
         startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(startIntent);

--- a/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
+++ b/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
@@ -48,7 +48,6 @@ import app.intra.net.socks.SocksVpnAdapter;
 import app.intra.net.split.SplitVpnAdapter;
 import app.intra.sys.NetworkManager.NetworkListener;
 import app.intra.ui.MainActivity;
-import com.crashlytics.android.Crashlytics;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -324,7 +323,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
     VpnController.getInstance().onStartComplete(this, vpnAdapter != null);
     if (vpnAdapter == null) {
-      Crashlytics.log(Log.WARN, LOG_TAG, "Failed to startVpn VPN adapter");
+      LogWrapper.log(Log.WARN, LOG_TAG, "Failed to startVpn VPN adapter");
       stopSelf();
     }
   }
@@ -342,13 +341,13 @@ public class IntraVpnService extends VpnService implements NetworkListener,
     if (vpnAdapter != null) {
       vpnAdapter.start();
     } else {
-      Crashlytics.log(Log.WARN, LOG_TAG, "Restart failed");
+      LogWrapper.log(Log.WARN, LOG_TAG, "Restart failed");
     }
   }
 
   @Override
   public void onCreate() {
-    Crashlytics.log(Log.INFO, LOG_TAG, "Creating DNS VPN service");
+    LogWrapper.log(Log.INFO, LOG_TAG, "Creating DNS VPN service");
     VpnController.getInstance().setIntraVpnService(this);
 
     firebaseAnalytics = FirebaseAnalytics.getInstance(this);
@@ -357,7 +356,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
   }
 
   public void signalStopService(boolean userInitiated) {
-    Crashlytics.log(
+    LogWrapper.log(
         Log.INFO,
         LOG_TAG,
         String.format("Received stop signal. User initiated: %b", userInitiated));
@@ -426,12 +425,12 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
   private synchronized void startVpnAdapter() {
     if (vpnAdapter == null) {
-      Crashlytics.log(Log.INFO, LOG_TAG, "Starting DNS resolver");
+      LogWrapper.log(Log.INFO, LOG_TAG, "Starting DNS resolver");
       vpnAdapter = makeVpnAdapter();
       if (vpnAdapter != null) {
         vpnAdapter.start();
       } else {
-        Crashlytics.log(Log.ERROR, LOG_TAG, "Failed to start VPN adapter!");
+        LogWrapper.log(Log.ERROR, LOG_TAG, "Failed to start VPN adapter!");
       }
     }
   }
@@ -446,7 +445,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
   @Override
   public synchronized void onDestroy() {
-    Crashlytics.log(Log.INFO, LOG_TAG, "Destroying DNS VPN service");
+    LogWrapper.log(Log.INFO, LOG_TAG, "Destroying DNS VPN service");
 
     PreferenceManager.getDefaultSharedPreferences(this).
         unregisterOnSharedPreferenceChangeListener(this);
@@ -468,7 +467,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
   @Override
   public void onRevoke() {
-    Crashlytics.log(Log.WARN, LOG_TAG, "VPN service revoked.");
+    LogWrapper.log(Log.WARN, LOG_TAG, "VPN service revoked.");
     stopSelf();
 
     // Disable autostart if VPN permission is revoked.
@@ -490,7 +489,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
         // Play Store incompatibility is a known issue, so always exclude it.
         builder = builder.addDisallowedApplication("com.android.vending");
       } catch (PackageManager.NameNotFoundException e) {
-        Crashlytics.logException(e);
+        LogWrapper.logException(e);
         Log.e(LOG_TAG, "Failed to exclude an app", e);
       }
     }
@@ -545,7 +544,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
   // NetworkListener interface implementation
   @Override
   public void onNetworkConnected(NetworkInfo networkInfo) {
-    Crashlytics.log(Log.INFO, LOG_TAG, "Connected event.");
+    LogWrapper.log(Log.INFO, LOG_TAG, "Connected event.");
     setNetworkConnected(true);
     // This code is used to start the VPN for the first time, but startVpn is idempotent, so we can
     // call it every time. startVpn performs network activity so it has to run on a separate thread.
@@ -561,7 +560,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
   @Override
   public void onNetworkDisconnected() {
-    Crashlytics.log(Log.INFO, LOG_TAG, "Disconnected event.");
+    LogWrapper.log(Log.INFO, LOG_TAG, "Disconnected event.");
     setNetworkConnected(false);
     VpnController.getInstance().onConnectionStateChanged(this, null);
   }

--- a/Android/app/src/main/java/app/intra/sys/LogWrapper.java
+++ b/Android/app/src/main/java/app/intra/sys/LogWrapper.java
@@ -15,13 +15,21 @@ limitations under the License.
 */
 package app.intra.sys;
 
+import android.util.Log;
+import app.intra.BuildConfig;
 import com.crashlytics.android.Crashlytics;
 
 /**
- * Wrapper for Firebase Crash Reporting.  This allows unit testing of classes that contain logging.
+ * Wrapper for Crashlytics.  This allows unit testing of classes that contain logging and allows
+ * us to cleanly disable Crashlytics in debug builds.
+ * See https://stackoverflow.com/questions/16986753/how-to-disable-crashlytics-during-development
  */
 public class LogWrapper {
-  public static void report(Throwable t) {
+  public static void logException(Throwable t) {
+    if (BuildConfig.DEBUG) {
+      Log.e("LogWrapper", "Error", t);
+      return;
+    }
     try {
       Crashlytics.logException(t);
     } catch (IllegalStateException e) {
@@ -29,7 +37,11 @@ public class LogWrapper {
     }
   }
 
-  public static void logcat(int i, String s, String s1) {
+  public static void log(int i, String s, String s1) {
+    if (BuildConfig.DEBUG) {
+      Log.println(i, s, s1);
+      return;
+    }
     try {
       Crashlytics.log(i, s, s1);
     } catch (IllegalStateException e) {

--- a/Android/app/src/main/java/app/intra/sys/PersistentState.java
+++ b/Android/app/src/main/java/app/intra/sys/PersistentState.java
@@ -22,7 +22,6 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import app.intra.R;
 import app.intra.ui.settings.Untemplate;
-import com.crashlytics.android.Crashlytics;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
@@ -107,7 +106,7 @@ public class PersistentState {
     }
 
     if (url == null) {
-      Crashlytics.log(Log.WARN, LOG_TAG, "Legacy domain is unrecognized");
+      LogWrapper.log(Log.WARN, LOG_TAG, "Legacy domain is unrecognized");
       return;
     }
     setServerUrl(context, url);
@@ -138,7 +137,7 @@ public class PersistentState {
       URL parsed = new URL(url);
       return parsed.getHost();
     } catch (MalformedURLException e) {
-      Crashlytics.log(Log.WARN, LOG_TAG, "Stored URL is corrupted");
+      LogWrapper.log(Log.WARN, LOG_TAG, "Stored URL is corrupted");
       return null;
     }
   }

--- a/Android/app/src/main/java/app/intra/ui/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/ui/MainActivity.java
@@ -68,6 +68,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import app.intra.R;
 import app.intra.net.doh.ServerConnection;
 import app.intra.net.doh.Transaction;
+import app.intra.sys.LogWrapper;
 import app.intra.sys.Names;
 import app.intra.sys.PersistentState;
 import app.intra.sys.QueryTracker;
@@ -75,7 +76,6 @@ import app.intra.sys.VpnController;
 import app.intra.sys.VpnState;
 import app.intra.ui.settings.ServerChooser;
 import app.intra.ui.settings.SettingsFragment;
-import com.crashlytics.android.Crashlytics;
 import com.google.android.material.navigation.NavigationView;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -396,7 +396,7 @@ public class MainActivity extends AppCompatActivity
     VpnController controller = VpnController.getInstance();
     VpnState state = controller.getState(this);
     if (state.activationRequested && !state.on) {
-      Crashlytics.log(Log.INFO, LOG_TAG, "Autostart enabled");
+      LogWrapper.log(Log.INFO, LOG_TAG, "Autostart enabled");
       prepareAndStartDnsVpn();
     }
   }
@@ -425,7 +425,7 @@ public class MainActivity extends AppCompatActivity
         startDnsVpnService();
       }
     } else {
-      Crashlytics.log(Log.ERROR, LOG_TAG, "Device does not support system-wide VPN mode.");
+      LogWrapper.log(Log.ERROR, LOG_TAG, "Device does not support system-wide VPN mode.");
     }
   }
 
@@ -441,7 +441,7 @@ public class MainActivity extends AppCompatActivity
     } catch (NullPointerException e) {
       // This exception is not mentioned in the documentation, but it has been encountered by Intra
       // users and also by other developers, e.g. https://stackoverflow.com/questions/45470113.
-      Crashlytics.logException(e);
+      LogWrapper.logException(e);
       return false;
     }
     if (prepareVpnIntent != null) {
@@ -544,7 +544,7 @@ public class MainActivity extends AppCompatActivity
         }
       }
     } catch (SocketException e) {
-      Crashlytics.logException(e);
+      LogWrapper.logException(e);
     }
     return false;
   }

--- a/Android/app/src/main/java/app/intra/ui/RecyclerAdapter.java
+++ b/Android/app/src/main/java/app/intra/ui/RecyclerAdapter.java
@@ -28,7 +28,7 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import app.intra.R;
 import app.intra.net.dns.DnsPacket;
-import com.crashlytics.android.Crashlytics;
+import app.intra.sys.LogWrapper;
 import com.google.common.net.InternetDomainName;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -87,7 +87,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     try {
       countryMap = new CountryMap(activity.getAssets());
     } catch (IOException e) {
-      Crashlytics.logException(e);
+      LogWrapper.logException(e);
     }
   }
 

--- a/Android/app/src/main/java/app/intra/ui/settings/SettingsFragment.java
+++ b/Android/app/src/main/java/app/intra/ui/settings/SettingsFragment.java
@@ -26,8 +26,8 @@ import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import app.intra.R;
+import app.intra.sys.LogWrapper;
 import app.intra.sys.PersistentState;
-import com.crashlytics.android.Crashlytics;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -159,7 +159,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         // Thread was interrupted.  This is probably fine.
       } catch (ExecutionException e) {
         // Something bad happened during the async task.
-        Crashlytics.logException(e);
+        LogWrapper.logException(e);
       }
     }
     return appList;


### PR DESCRIPTION
Unlike Firebase Crash Reporting, Crashlytics does not permit
the use of its logging functions when disabled in debug mode.
The easiest solution seems to be to avoid performing these
calls in debug builds.