### PR TITLE
Enable proguard for release builds

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -47,8 +47,10 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro'
             signingConfig signingConfigs.config
             resValue("bool", "FIREBASE_ENABLED", "true")
         }

--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -1,17 +1,8 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/alalama/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Obfuscation makes stack traces harder to understand in release builds.
+# The minor size savings isn't worth making debugging harder.
+-dontobfuscate
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Our tun2socks library calls back into this class when printing log
+# messages.  Proguard can't see that external reference to the log
+# method, so we need to mark it for preservation explicitly.
+-keep public class org.outline.tun2socks.Tun2SocksJni { *; }


### PR DESCRIPTION
This is the recommended build configuration for Android.
It's also required because otherwise (thanks to Guava) we
have more than 65536 methods, which is the limit for one
Android DEX file, and support for multi-DEX APKs on older
Android versions is limited.  Proguard removes all the
unused methods, keeping us under the DEX file limit (and
also reducing the APK size).