### PR TITLE
Update google-services.json

### DIFF
--- a/Android/app/google-services.json
+++ b/Android/app/google-services.json
@@ -8,7 +8,7 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:80496146927:android:e92bfb17e27640f0",
+        "mobilesdk_app_id": "1:80496146927:android:755859391e691a80",
         "android_client_info": {
           "package_name": "app.intra"
         }
@@ -25,15 +25,42 @@
         }
       ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
         "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
+          "other_platform_oauth_client": [
+            {
+              "client_id": "80496146927-85roh68ingqilf3ea2g9lhh8uf5rgv85.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:80496146927:android:e92bfb17e27640f0",
+        "android_client_info": {
+          "package_name": "com.google.jigsaw.dnsprotection"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "80496146927-85roh68ingqilf3ea2g9lhh8uf5rgv85.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCzbuaavnJeTtLPIYOgEvCk4R1sgCsfaxc"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "80496146927-85roh68ingqilf3ea2g9lhh8uf5rgv85.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Crashlytics depends on having an exact match on the
package name, in a way that Firebase Crash Reporting
does not.  I added a new Firebase app ID for "app.intra"
and regenerated google-services.json.  This appears to
have solved the problem.