### PR TITLE
Switch Google to RFC DoH by default

### DIFF
--- a/Android/app/src/main/java/app/intra/net/doh/ServerConnectionFactory.java
+++ b/Android/app/src/main/java/app/intra/net/doh/ServerConnectionFactory.java
@@ -44,7 +44,7 @@ public class ServerConnectionFactory {
   /**
    * @return True if these URLs represents the same server.
    */
-  public boolean equalUrls(String url1, String url2) {
+  public static boolean equalUrls(Context context, String url1, String url2) {
     // Convert null and "" into "https://dns.google/dns-query", which is the default URL.
     url1 = PersistentState.expandUrl(context, url1);
     url2 = PersistentState.expandUrl(context, url2);
@@ -78,7 +78,7 @@ public class ServerConnectionFactory {
   }
 
   public ServerConnection get(final String url) {
-    if (equalUrls(url, null)) {
+    if (equalUrls(context, url, null)) {
       // Try to use standard DOH to the default server (i.e. Google).
       ServerConnection s = getStandardConnection(PersistentState.expandUrl(context, url));
       if (s != null) {

--- a/Android/app/src/main/java/app/intra/ui/settings/ServerChooser.java
+++ b/Android/app/src/main/java/app/intra/ui/settings/ServerChooser.java
@@ -22,6 +22,7 @@ import android.os.Build;
 import android.util.AttributeSet;
 import androidx.preference.DialogPreference;
 import app.intra.R;
+import app.intra.sys.PersistentState;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
@@ -34,7 +35,6 @@ import java.util.Locale;
 public class ServerChooser extends DialogPreference {
   private String url;
   private String summaryTemplate;
-  private String defaultDomain;
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public ServerChooser(Context context) {
@@ -66,8 +66,6 @@ public class ServerChooser extends DialogPreference {
     setDialogLayoutResource(R.layout.servers);
     summaryTemplate =
         context.getResources().getString(R.string.server_choice_summary);
-    defaultDomain =
-        context.getResources().getString(R.string.domain0);
     setPositiveButtonText(R.string.intro_accept);
   }
 
@@ -94,16 +92,13 @@ public class ServerChooser extends DialogPreference {
 
   // Updates the "Currently <servername>" summary under the title.
   private void updateSummary(String url) {
+    url = PersistentState.expandUrl(getContext(), url);
     String domain = null;
-    if (url == null || url.isEmpty()) {
-      domain = defaultDomain;
-    } else {
-      try {
-        URL parsed = new URL(url);
-        domain = parsed.getHost();
-      } catch (MalformedURLException e) {
-        // Leave domain null.
-      }
+    try {
+      URL parsed = new URL(url);
+      domain = parsed.getHost();
+    } catch (MalformedURLException e) {
+      // Leave domain null.
     }
     if (domain != null) {
       setSummary(String.format(Locale.ROOT, summaryTemplate, domain));

--- a/Android/app/src/main/java/app/intra/ui/settings/ServerChooserFragment.java
+++ b/Android/app/src/main/java/app/intra/ui/settings/ServerChooserFragment.java
@@ -34,6 +34,7 @@ import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.PreferenceDialogFragmentCompat;
 import app.intra.R;
+import app.intra.sys.PersistentState;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -195,15 +196,11 @@ public class ServerChooserFragment extends PreferenceDialogFragmentCompat
 
         // Check if we are using one of the built-in servers.
         int index = -1;
-        if (url == null || url.isEmpty()) {
-            // TODO: Remove special case once Google DNS moves to standard DOH.
-            index = 0;
-        } else {
-            for (int i = 1; i < urls.length; ++i) {
-                if (urls[i].equals(url)) {
-                    index = i;
-                    break;
-                }
+        String expanded = PersistentState.expandUrl(getContext(), url);
+        for (int i = 0; i < urls.length; ++i) {
+            if (urls[i].equals(expanded)) {
+                index = i;
+                break;
             }
         }
 

--- a/Android/app/src/main/res/values/servers.xml
+++ b/Android/app/src/main/res/values/servers.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- Each DOH server is defined by a URL (which is the actual DOH endpoint).  However, Google DNS
-   uses a pre-standardization version of DOH, and has additional bootstrap optimizations beyond
-   standard URL connection.  We indicate this special case by leaving the URL blank, and maintaining
-   this "domain0" value instead. TODO: Remove "domain0" once Google launches standard DOH. -->
-  <string name="domain0" translatable="false">dns.google.com</string>
-  <string name="url0" translatable="false"></string>
+   was previously configured by domain, in early versions of Intra.-->
+  <string name="legacy_domain0" translatable="false">dns.google.com</string>
+  <string name="url0" translatable="false">https://dns.google/dns-query</string>
   <string name="name0" translatable="false">Google Public DNS</string>
-  <string name="ips0" translatable="false"></string>
+  <string name="ips0" translatable="false">8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844</string>
   <string name="description0" description="Describes Google's DNS resolver (i.e. DNS server).">
     Large global resolver operated by Google.
   </string>


### PR DESCRIPTION
This change still falls back to pre-standard DoH if
RFC DoH isn't working.

This should future-proof Intra against the turndown of
Google's pre-standard DoH service.