### PR TITLE
Fix a bug in try-all logic

### DIFF
--- a/Android/app/src/main/java/app/intra/ui/MainActivity.java
+++ b/Android/app/src/main/java/app/intra/ui/MainActivity.java
@@ -310,7 +310,7 @@ public class MainActivity extends AppCompatActivity
           // showing a DialogFragment directly causes an IllegalStateException.  Using
           // commitAllowingStateLoss() avoids this problem.
           getSupportFragmentManager().beginTransaction()
-              .add(new ServerApprovalDialogFragment(), "dialog")
+              .add(new ServerApprovalDialogFragment(index), "dialog")
               .commitAllowingStateLoss();
         } else {
           Toast.makeText(this, R.string.all_servers_failed, Toast.LENGTH_LONG).show();


### PR DESCRIPTION
This bug, introduced in 1.1.7, was causing try-all to always
report Google DNS as the fastest option.