### PR TITLE
Wrap all FirebaseRemoteConfig calls in try-catch

### DIFF
--- a/Android/app/src/main/java/app/intra/net/go/TLSProbe.java
+++ b/Android/app/src/main/java/app/intra/net/go/TLSProbe.java
@@ -18,8 +18,8 @@ package app.intra.net.go;
 import android.content.Context;
 import android.os.Bundle;
 import app.intra.sys.Names;
+import app.intra.sys.RemoteConfig;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import java.io.IOException;
 import java.net.URL;
 import javax.net.ssl.SSLHandshakeException;
@@ -62,8 +62,6 @@ class TLSProbe {
   }
 
   static Result run(Context context) {
-    String[] domains = FirebaseRemoteConfig.getInstance()
-        .getString("tls_probe_servers").split(",");
-    return run(context, domains);
+    return run(context, RemoteConfig.getTlsProbeServers());
   }
 }

--- a/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
+++ b/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
@@ -46,7 +46,6 @@ import app.intra.net.split.SplitVpnAdapter;
 import app.intra.sys.NetworkManager.NetworkListener;
 import app.intra.ui.MainActivity;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import java.util.Calendar;
 
 public class IntraVpnService extends VpnService implements NetworkListener,

--- a/Android/app/src/main/java/app/intra/sys/RemoteConfig.java
+++ b/Android/app/src/main/java/app/intra/sys/RemoteConfig.java
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package app.intra.sys;
 
+import android.content.Context;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 
 /**
@@ -25,7 +27,29 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
  */
 public class RemoteConfig {
   public static Task<Boolean> update() {
-    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
-    return config.fetchAndActivate();
+    try {
+      FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
+      return config.fetchAndActivate();
+    } catch (IllegalStateException e) {
+      return Tasks.forResult(false);
+    }
+  }
+
+  public static String[] getTlsProbeServers() {
+    try {
+      return FirebaseRemoteConfig.getInstance()
+          .getString("tls_probe_servers").split(",");
+    } catch (IllegalStateException e) {
+      return new String[0];
+    }
+  }
+
+  public static boolean getUseGoDoh() {
+    try {
+      return FirebaseRemoteConfig.getInstance()
+          .getBoolean("use_go_doh");
+    } catch (IllegalStateException e) {
+      return false;
+    }
   }
 }

--- a/Android/app/src/main/java/app/intra/sys/RemoteConfig.java
+++ b/Android/app/src/main/java/app/intra/sys/RemoteConfig.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package app.intra.sys;
 
-import android.content.Context;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
@@ -31,6 +30,7 @@ public class RemoteConfig {
       FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
       return config.fetchAndActivate();
     } catch (IllegalStateException e) {
+      LogWrapper.logException(e);
       return Tasks.forResult(false);
     }
   }
@@ -40,6 +40,7 @@ public class RemoteConfig {
       return FirebaseRemoteConfig.getInstance()
           .getString("tls_probe_servers").split(",");
     } catch (IllegalStateException e) {
+      LogWrapper.logException(e);
       return new String[0];
     }
   }
@@ -49,6 +50,7 @@ public class RemoteConfig {
       return FirebaseRemoteConfig.getInstance()
           .getBoolean("use_go_doh");
     } catch (IllegalStateException e) {
+      LogWrapper.logException(e);
       return false;
     }
   }


### PR DESCRIPTION
Play Store reporting indicates that FirebaseRemoteConfig.getInstance
is throwing (unchecked) IllegalStateException for a large number of
users, resulting in an app crash.