### PR TITLE
Expand null URL before passing it to Go

### DIFF
--- a/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
@@ -109,18 +109,15 @@ public class GoVpnAdapter extends VpnAdapter {
     listener = new GoIntraListener(vpnService);
     String dohURL = PersistentState.getServerUrl(vpnService);
 
-    Transport transport;
+    Transport transport = null;
     if (RemoteConfig.getUseGoDoh()) {
       try {
         transport = makeDohTransport(dohURL);
       } catch (Exception e) {
         // Fall back to ServerConnection if Go-DOH setup fails.
-        // TODO: Report this failure properly instead of silently falling back.
+        // TODO: Expose this failure to the user instead of silently falling back.
         LogWrapper.logException(e);
-        transport = null;
       }
-    } else {
-      transport = null;
     }
 
     try {

--- a/Android/app/src/main/java/app/intra/sys/VpnController.java
+++ b/Android/app/src/main/java/app/intra/sys/VpnController.java
@@ -47,7 +47,7 @@ public class VpnController {
     this.intraVpnService = intraVpnService;
   }
 
-  synchronized void onConnectionStateChanged(Context context, ServerConnection.State state) {
+  public synchronized void onConnectionStateChanged(Context context, ServerConnection.State state) {
     if (intraVpnService == null) {
       // User clicked disable while the connection state was changing.
       return;


### PR DESCRIPTION
This was causing total failure when using Go-DOH in fresh installs
and installs that had never adjusted the server setting.