### PR TITLE
Use Go-DOH by default

### DIFF
--- a/Android/app/src/main/java/app/intra/sys/firebase/RemoteConfig.java
+++ b/Android/app/src/main/java/app/intra/sys/firebase/RemoteConfig.java
@@ -54,11 +54,11 @@ public class RemoteConfig {
       return false;
     }
     try {
-      return FirebaseRemoteConfig.getInstance()
-          .getBoolean("use_go_doh");
+      return !FirebaseRemoteConfig.getInstance()
+          .getBoolean("disable_go_doh");
     } catch (IllegalStateException e) {
       LogWrapper.logException(e);
-      return false;
+      return true;
     }
   }
 }


### PR DESCRIPTION
Go-DOH has been deployed globally for the past month
with positive results.  This changes makes Go-DOH the
default, with a remote-config escape hatch if we discover a
serious bug.