### PR TITLE
Change the IP and domain for Applied Privacy

### DIFF
--- a/Android/app/src/main/res/values/servers.xml
+++ b/Android/app/src/main/res/values/servers.xml
@@ -35,13 +35,13 @@
   </string>
   <string name="website3" translatable="false">https://cleanbrowsing.org/</string>
 
-  <string name="url4" translatable="false">https://doh.appliedprivacy.net/query</string>
+  <string name="url4" translatable="false">https://doh.applied-privacy.net/query</string>
   <string name="name4" translatable="false">Foundation for Applied Privacy</string>
-  <string name="ips4" translatable="false">37.252.185.229,2a00:63c1:a:229::2</string>
+  <string name="ips4" translatable="false">93.177.65.183,2a03:4000:38:53c::2</string>
   <string name="description4" description="Describes a DNS resolver (i.e. DNS server). [CHAR_LIMIT=NONE]">
     Server in Austria operated by a non-profit privacy group.
   </string>
-  <string name="website4" translatable="false">https://appliedprivacy.net/services/dns/</string>
+  <string name="website4" translatable="false">https://applied-privacy.net/services/dns/</string>
 
   <string name="url5" translatable="false">https://doh.powerdns.org/</string>
   <string name="name5" translatable="false">PowerDNS</string>


### PR DESCRIPTION
This server operator has relocated their services.

Existing users configuration will not be altered, so
users will have to select this server from the menu again.

Fixes #246