### PR TITLE
Update outline-go-tun2socks

### DIFF
--- a/Android/tun2socks/README.md
+++ b/Android/tun2socks/README.md
@@ -1,2 +1,2 @@
 This copy of tun2socks.aar is built from https://github.com/Jigsaw-Code/outline-go-tun2socks, at
-commit c7bc52483d73f3e44f5962cb86e5384cd48a06e2.  It is used here under the Apache 2.0 license.
+commit a0a1167c6cd706600db5ca0d128f043f05fd713b.  It is used here under the Apache 2.0 license.


### PR DESCRIPTION
This version of outline-go-tun2socks contains Choir-related fixes.