### PR TITLE
Avoid a double-close on the VPN file descriptor

### DIFF
--- a/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
@@ -122,8 +122,10 @@ public class GoVpnAdapter {
     try {
       LogWrapper.log(Log.INFO, LOG_TAG, "Starting go-tun2socks");
       Transport transport = makeDohTransport(dohURL);
-      tunnel = Tun2socks.connectIntraTunnel(tunFd.getFd(), fakeDns,
+      // connectIntraTunnel takes ownership of the file descriptor.
+      tunnel = Tun2socks.connectIntraTunnel(tunFd.detachFd(), fakeDns,
           transport, getProtector(), listener);
+      tunFd = null;
     } catch (Exception e) {
       LogWrapper.logException(e);
       VpnController.getInstance().onConnectionStateChanged(vpnService, IntraVpnService.State.FAILING);


### PR DESCRIPTION
Currently, both Java and Go try to close the VPN file descriptor when
the file object is garbage-collected, leading to a double-close.  This
is detected by fdsan on Android 11, resulting in a crash.