### PR TITLE
Mark the VPN as unmetered

### DIFF
--- a/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
@@ -168,6 +168,9 @@ public class GoVpnAdapter {
       if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
         builder.addDisallowedApplication(vpnService.getPackageName());
       }
+      if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+        builder.setMetered(false); // There's no charge for using Intra.
+      }
       return builder.establish();
     } catch (Exception e) {
       LogWrapper.logException(e);


### PR DESCRIPTION
Starting in Android Q (10), VPNs are marked as "metered" by default,
preventing low-priority tasks like backups from running while the VPN is
on.  Intra is not metered, so we have to mark it as such explicitly.