### PR TITLE
Incorporate updated outline-go-tun2socks

### DIFF
--- a/Android/app/src/main/java/app/intra/net/go/GoIntraListener.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoIntraListener.java
@@ -37,7 +37,7 @@ import split.RetryStats;
  * when a socket has concluded, with performance metrics for that socket, and this class forwards
  * those metrics to Firebase.
  */
-public class GoIntraListener implements tunnel.IntraListener {
+public class GoIntraListener implements intra.Listener {
 
   // UDP is often used for one-off messages and pings.  The relative overhead of reporting metrics
   // on these short messages would be large, so we only report metrics on sockets that transfer at

--- a/Android/app/src/main/java/app/intra/net/go/GoProber.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoProber.java
@@ -43,7 +43,7 @@ public class GoProber extends Prober {
         // Protection isn't needed for Lollipop+, or if the VPN is not active.
         Protector protector = VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP ? null :
             VpnController.getInstance().getIntraVpnService();
-        Transport transport = Tun2socks.newDoHTransport(url, dohIPs, protector, null);
+        Transport transport = Tun2socks.newDoHTransport(url, dohIPs, protector, null, null);
         if (transport == null) {
           callback.onCompleted(false);
           return;

--- a/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
@@ -41,7 +41,6 @@ import java.net.URL;
 import java.util.Locale;
 import protect.Protector;
 import tun2socks.Tun2socks;
-import tunnel.IntraTunnel;
 
 /**
  * This is a VpnAdapter that captures all traffic and routes it through a go-tun2socks instance with
@@ -88,7 +87,7 @@ public class GoVpnAdapter {
   private ParcelFileDescriptor tunFd;
 
   // The Intra session object from go-tun2socks.  Initially null.
-  private IntraTunnel tunnel;
+  private intra.Tunnel tunnel;
   private GoIntraListener listener;
 
   public static GoVpnAdapter establish(@NonNull IntraVpnService vpnService) {
@@ -210,7 +209,7 @@ public class GoVpnAdapter {
     long startTime = SystemClock.elapsedRealtime();
     final doh.Transport transport;
     try {
-      transport = Tun2socks.newDoHTransport(realUrl, dohIPs, getProtector(), listener);
+      transport = Tun2socks.newDoHTransport(realUrl, dohIPs, getProtector(), null, listener);
     } catch (Exception e) {
       AnalyticsWrapper.get(vpnService).logBootstrapFailed(host);
       throw e;

--- a/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
+++ b/Android/app/src/main/java/app/intra/net/go/GoVpnAdapter.java
@@ -121,10 +121,9 @@ public class GoVpnAdapter {
     try {
       LogWrapper.log(Log.INFO, LOG_TAG, "Starting go-tun2socks");
       Transport transport = makeDohTransport(dohURL);
-      // connectIntraTunnel takes ownership of the file descriptor.
-      tunnel = Tun2socks.connectIntraTunnel(tunFd.detachFd(), fakeDns,
+      // connectIntraTunnel makes a copy of the file descriptor.
+      tunnel = Tun2socks.connectIntraTunnel(tunFd.getFd(), fakeDns,
           transport, getProtector(), listener);
-      tunFd = null;
     } catch (Exception e) {
       LogWrapper.logException(e);
       VpnController.getInstance().onConnectionStateChanged(vpnService, IntraVpnService.State.FAILING);

--- a/Android/tun2socks/README.md
+++ b/Android/tun2socks/README.md
@@ -1,2 +1,2 @@
 This copy of tun2socks.aar is built from https://github.com/Jigsaw-Code/outline-go-tun2socks, at
-commit a0a1167c6cd706600db5ca0d128f043f05fd713b.  It is used here under the Apache 2.0 license.
+commit a855c4a7a4591f61603981d353af187f38e90b22.  It is used here under the Apache 2.0 license.


### PR DESCRIPTION
This slightly changes the names used in the Go-Java interface
and adds new arguments for certificate authentication (not yet used).