### PR TITLE
Disallow bypass when vpn is lockdown

### DIFF
--- a/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
+++ b/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
@@ -374,9 +374,12 @@ public class IntraVpnService extends VpnService implements NetworkListener,
   public VpnService.Builder newBuilder() {
     VpnService.Builder builder = new VpnService.Builder();
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      // Some WebRTC apps rely on the ability to bind to specific interfaces, which is only
-      // possible if we allow bypass.
-      builder = builder.allowBypass();
+      // unprivileged apps cannot bind to interfaces outside of the vpn when in lockdown mode
+      if (!isVpnLockdown()) {
+        // Some WebRTC apps rely on the ability to bind to specific interfaces, which is only
+        // possible if we allow bypass.
+        builder = builder.allowBypass();
+      }
 
       try {
         // Workaround for any app incompatibility bugs.
@@ -471,5 +474,13 @@ public class IntraVpnService extends VpnService implements NetworkListener,
       }
     }
     return TextUtils.join(",", ips);
+  }
+
+  private boolean isVpnLockdown() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      return this.isLockdownEnabled();
+    } else {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Allowing network bypass on a vpn that's running in lockdown mode
causes it to lose internet connectivity. Prevent the vpn from entering
such a state at least on vpn-start / vpn-restart.