### PR TITLE
fix(crash): mark the VPN stop notification as immutable

### DIFF
--- a/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
+++ b/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
@@ -284,7 +284,7 @@ public class IntraVpnService extends VpnService implements NetworkListener,
       }
 
       PendingIntent mainActivityIntent = PendingIntent.getActivity(
-          this, 0, new Intent(this, MainActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
+          this, 0, new Intent(this, MainActivity.class), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       builder.setSmallIcon(R.drawable.ic_status_bar)
           .setContentTitle(getResources().getText(R.string.warning_title))


### PR DESCRIPTION
Android S+ [requires all PendingIntents](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability) to be marked as mutable
or immutable (usually the latter).  This change adds this
annotation to the PendingIntent used to surface Intra when it
is disabled.  This occurs most commonly when another VPN is
started.  Without this fix, Intra crashes when another VPN
is started during a session.