### PR TITLE
Restore "Excluded apps" functionality on Android 11

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
In recent Android API versions, `getInstalledApplications` only
shows basic system apps unless the manifest requests the
`QUERY_ALL_PACKAGES` permission.

See https://developer.android.com/training/package-visibility