### PR TITLE
add PureDNS to list of servers

### DIFF
--- a/Android/app/src/main/res/values-id/servers.xml
+++ b/Android/app/src/main/res/values-id/servers.xml
@@ -18,4 +18,5 @@
   <string name="description15">Resolver besar skala global yang dimiliki oleh Cisco.</string>
   <string name="description16">Dioperasikan oleh perusahaan layanan IT di London dan Bulgaria.</string>
   <string name="description17">Dioperasikan oleh Canadian Internet Registration Authority.</string>
+  <string name="description18">Server di wilayah Asia-Pasifik yang dioperasikan oleh grup privasi nirlaba.</string>
 </resources>

--- a/Android/app/src/main/res/values/servers.xml
+++ b/Android/app/src/main/res/values/servers.xml
@@ -134,4 +134,12 @@
     Operated by the Canadian Internet Registration Authority.
   </string>
   <string name="website17" translatable="false">https://www.cira.ca/cybersecurity-services/canadian-shield</string>
+
+  <string name="url18" translatable="false">https://puredns.org/dns-query</string>
+  <string name="name18" translatable="false">PureDNS</string>
+  <string name="ips18" translatable="false"></string>
+  <string name="description18" description="See https://puredns.org/ [CHAR_LIMIT=NONE]">
+    Server in Asia-Pacific region operated by a non-profit privacy group.
+  </string>
+  <string name="website18" translatable="false">https://puredns.org/</string>
 </resources>


### PR DESCRIPTION
PureDNS is a privacy-respecting DNS resolver in the APAC region. For more information about this service, visit https://puredns.org.