### PR TITLE
Update 42l's name in servers list

### DIFF
--- a/Android/app/src/main/res/values/servers.xml
+++ b/Android/app/src/main/res/values/servers.xml
@@ -87,13 +87,13 @@
   </string>
   <string name="website11" translatable="false">https://www.aa.net.uk/dns/</string>
 
-  <string name="url12" translatable="false">https://doh.42l.fr/dns-query</string>
-  <string name="name12" translatable="false">42l Association</string>
+  <string name="url12" translatable="false">https://doh.lacontrevoie.fr/dns-query</string>
+  <string name="name12" translatable="false">La Contre-Voie</string>
   <string name="ips12" translatable="false">45.155.171.163,2a09:6382:4000:3:45:155:171:163</string>
-  <string name="description12" description="See https://42l.fr/DoH-service [CHAR_LIMIT=NONE]">
+  <string name="description12" description="See https://lacontrevoie.fr/en/services/doh/ [CHAR_LIMIT=NONE]">
     Server in Nice, France, operated by a French non-profit promoting free culture and ethics.
   </string>
-  <string name="website12" translatable="false">https://42l.fr/DoH-service</string>
+  <string name="website12" translatable="false">https://lacontrevoie.fr/en/services/doh/</string>
 
   <string name="url13" translatable="false">https://dns.digitale-gesellschaft.ch/dns-query</string>
   <string name="name13" translatable="false">Digitale Gesellschaft</string>


### PR DESCRIPTION
Hello!

We recently renamed our nonprofit association from « 42l Association » to « La Contre-Voie », I thought about updating it in your project’s server list.

We’ve set up 301 redirects from our previous website (42l.fr) to our new one (lacontrevoie.fr).

In some weeks, we will also return a 301 redirect from `doh.42l.fr/dns-query` to `doh.lacontrevoie.fr/dns-query`. It shouldn’t impact your users at all if your client is following HTTP redirects. If it doesn’t, you may want to update the list promptly.

Our IPs (v4, v6) are still the same.

Have a nice day,

Neil

NB: I accept the « Contributor Covenant » but I won’t sign it since it requires a Google account and I don’t have one.