### PR TITLE
fix: crash in work profile due to exceptions thrown by TileService

### DIFF
--- a/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
+++ b/Android/app/src/main/java/app/intra/sys/IntraVpnService.java
@@ -336,8 +336,14 @@ public class IntraVpnService extends VpnService implements NetworkListener,
 
   private void updateQuickSettingsTile() {
     if (VERSION.SDK_INT >= VERSION_CODES.N) {
-      TileService.requestListeningState(this,
-              new ComponentName(this, IntraTileService.class));
+      try {
+        TileService.requestListeningState(this,
+                new ComponentName(this, IntraTileService.class));
+      } catch (SecurityException ignored) {
+      } catch (IllegalArgumentException ignored) {
+        // Starting from API level 33, TileService will throw exceptions from apps in Work Profile
+        // See: https://developer.android.com/reference/android/service/quicksettings/TileService
+      }
     }
   }
 


### PR DESCRIPTION
I fixed a crash issue caused by: [`TileService.requestListeningState`](https://developer.android.com/reference/android/service/quicksettings/TileService#requestListeningState(android.content.Context,%20android.content.ComponentName)) throwing exceptions if the user of the context is not the current user (might be a work profile user).

This is the new behavior since API level 33, so previously this issue is not found.