### PR TITLE
split: copyOnce may be called more than once

### DIFF
--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -351,11 +351,11 @@ func copyOnce(dst io.Writer, src io.Reader) (int64, error) {
 
 func (r *retrier) ReadFrom(reader io.Reader) (bytes int64, err error) {
 	for !r.retryCompleted() {
-		var b int64
-		if b, err = copyOnce(r, reader); err != nil {
+		n, e := copyOnce(r, reader)
+		bytes += n
+		if err = e; err != nil {
 			return
 		}
-		bytes += b
 	}
 
 	var b int64

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -351,9 +351,11 @@ func copyOnce(dst io.Writer, src io.Reader) (int64, error) {
 
 func (r *retrier) ReadFrom(reader io.Reader) (bytes int64, err error) {
 	for !r.retryCompleted() {
-		if bytes, err = copyOnce(r, reader); err != nil {
+		var b int64
+		if b, err = copyOnce(r, reader); err != nil {
 			return
 		}
+		bytes += b
 	}
 
 	var b int64


### PR DESCRIPTION
Called twice when `retrier.Write` succeeds and returns immediately (L319) without waiting on `<-retryCloseFlag` (L324).

https://github.com/Jigsaw-Code/Intra/blob/5c6d68dec9782c89a53fb3f37366299c0192d240/Android/app/src/go/intra/split/retrier.go#L317-L324