### PR TITLE
split: skip zero len writes

### DIFF
--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -328,11 +328,12 @@ func (r *retrier) Write(b []byte) (int, error) {
 			r.mutex.Lock()
 			r.mutex.Unlock()
 	
-			if len(leftover) > 0 {
-				m, err := r.conn.Write(leftover)
-				return n + m, err
+			if buf := b[n:]; len(buf) > 0 {
+				m, e := r.conn.Write(buf)
+				n += m
+				err = e
 			}
-			return n, nil
+			return n, err
 		}
 	}
 

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -324,12 +324,13 @@ func (r *retrier) Write(b []byte) (int, error) {
 			<-r.retryCompleteFlag
 	
 			r.mutex.Lock()
+			c := r.conn
 			r.mutex.Unlock()
 
 			// zero len writes are no-ops, but Quad9 servers
 			// are observed to respond better when these are skipped.
 			if buf := b[n:]; len(buf) > 0 {
-				m, e := r.conn.Write(buf)
+				m, e := c.Write(buf)
 				n += m
 				err = e
 			}

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -324,8 +324,12 @@ func (r *retrier) Write(b []byte) (int, error) {
 			<-r.retryCompleteFlag
 			r.mutex.Lock()
 			r.mutex.Unlock()
-			m, err := r.conn.Write(b[n:])
-			return n + m, err
+			leftover := b[n:]
+			if len(leftover) > 0 {
+				m, err := r.conn.Write(leftover)
+				return n + m, err
+			}
+			return n, nil
 		}
 	}
 

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -318,8 +318,6 @@ func (r *retrier) Write(b []byte) (int, error) {
 			if err == nil {
 				return n, nil
 			}
-
-			leftover := b[n:]
 			// A write error occurred on the provisional socket.  This should be handled
 			// by the retry procedure.  Block until we have a final socket (which will
 			// already have replayed b[:n]), and retry.

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -315,7 +315,7 @@ func (r *retrier) Write(b []byte) (int, error) {
 		}
 		r.mutex.Unlock()
 
-    if attempted {
+		if attempted {
 			if err == nil {
 				return n, nil
 			}

--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -325,7 +325,9 @@ func (r *retrier) Write(b []byte) (int, error) {
 	
 			r.mutex.Lock()
 			r.mutex.Unlock()
-	
+
+			// zero len writes are no-ops, but Quad9 servers
+			// are observed to respond better when these are skipped.
 			if buf := b[n:]; len(buf) > 0 {
 				m, e := r.conn.Write(buf)
 				n += m


### PR DESCRIPTION
I'm not sure why (as zero len writes are apparently no-op in Golang) but the Quad9 resolver (DNSCrypt over TCP) doesn't work without this check.