### PR TITLE
retrier: confirm splitHello to io.Writer.Write

### DIFF
--- a/Android/app/src/go/intra/split/retrier.go
+++ b/Android/app/src/go/intra/split/retrier.go
@@ -283,9 +283,11 @@ func splitHello(hello []byte, w io.Writer) (n int, splitLen int, err error) {
 	pkt = hello[splitLen-5:]
 	copy(pkt, hello[:5])
  	binary.BigEndian.PutUint16(pkt[3:5], recordLen-uint16(recordSplitLen))
-	var m int
-	m, err = w.Write(pkt)
-	n += m
+	_, err = w.Write(pkt)
+
+	// total written bytes after fragmentation will always be greater than the length
+	// of the input buffer, which may break clients expecting to not exceed it.
+	n = len(hello)
 	return
 }
 


### PR DESCRIPTION
The way our Intra fork is written, writing to `retrier` (`DuplexConn`) via `io.Copy` results in panic when total written bytes from TLS fragmentation exceeds the length of the input bytes; expected since this behaviour violates the [`io.Writer.Write`](https://pkg.go.dev/io#Writer) contract:

> It returns the number of bytes written from p (0 <= n <= len(p)) and any error encountered that caused the write to stop early. Write must return a non-nil error if it returns n < len(p).

https://github.com/celzero/firestack/commit/ba0c57c3851ce8c08c2f392b57a1890a936c803c