### PR TITLE
doh: use tls session cache

### DIFF
--- a/Android/app/src/go/doh/doh.go
+++ b/Android/app/src/go/doh/doh.go
@@ -204,13 +204,13 @@ func NewResolver(rawurl string, addrs []string, dialer *net.Dialer, auth ClientA
 		return nil, fmt.Errorf("No IP addresses for %s", t.hostname)
 	}
 
-	// Supply a client certificate during TLS handshakes.
-	var tlsconfig *tls.Config
+	// Use session cache to minimize repeat TLS handshake overhead.
+	tlsconfig := &tls.Config{
+		ClientSessionCache: tls.NewLRUClientSessionCache(64),
+	}
 	if auth != nil {
 		signer := newClientAuthWrapper(auth)
-		tlsconfig = &tls.Config{
-			GetClientCertificate: signer.GetClientCertificate,
-		}
+		tlsconfig.GetClientCertificate = signer.GetClientCertificate
 	}
 
 	// Override the dial function.


### PR DESCRIPTION
In our experiments with rethinkdns, employing a session cache reduces data consumed by DoH by 3x (500mb/mo down to 180mb/mo) and latency by upto 4x.